### PR TITLE
fix: Fixing the fiveg_nrf endpoint name

### DIFF
--- a/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
@@ -37,7 +37,7 @@ class DummyFiveGNRFRequirerCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.nrf_requirer = NRFRequires(self, "fiveg-nrf")
+        self.nrf_requirer = NRFRequires(self, "fiveg_nrf")
         self.framework.observe(self.nrf_requirer.on.nrf_available, self._on_nrf_available)
 
     def _on_nrf_available(self, event: NRFAvailableEvent):
@@ -67,7 +67,7 @@ class DummyFiveGNRFProviderCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.nrf_provider = NRFProvides(self, "fiveg-nrf")
+        self.nrf_provider = NRFProvides(self, "fiveg_nrf")
         self.framework.observe(
             self.on.fiveg_nrf_relation_joined, self._on_fiveg_nrf_relation_joined
         )
@@ -110,7 +110,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,7 +10,7 @@ output "app_name" {
 
 output "fiveg_nrf_endpoint" {
   description = "Name of the endpoint used to integrate with the NRF."
-  value       = "fiveg-nrf"
+  value       = "fiveg_nrf"
 }
 
 output "certificates_endpoint" {


### PR DESCRIPTION
# Description

fiveg_nrf endpoint name was different than the one in the metadata.yaml. This PR puts the correct name.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library