### PR TITLE
fix: Pinning Juju version to 3.3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+juju==3.3.0.0
 ops
 pydantic
 pytest-interface-tester

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,10 +10,10 @@ output "app_name" {
 
 output "fiveg_nrf_endpoint" {
   description = "Name of the endpoint used to integrate with the NRF."
-  value = "fiveg-nrf"
+  value       = "fiveg-nrf"
 }
 
 output "certificates_endpoint" {
   description = "Name of the endpoint used to integrate with the TLS certificates provider."
-  value = "certificates"
+  value       = "certificates"
 }


### PR DESCRIPTION
# Description

Pinning `juju` version to 3.3.0.0, which is last working. With 3.3.1.0 tests started failing because of 
```shell
 File "/home/ubuntu/github-runner/_work/sdcore-tests/sdcore-tests/.tox/integration/lib/python3.10/site-packages/juju/version.py", line 19, in <module>
    CLIENT_VERSION = re.search(r'\d+\.\d+\.\d+', open(VERSION_FILE_PATH).read().strip()).group()
FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/github-runner/_work/sdcore-tests/sdcore-tests/.tox/integration/lib/python3.10/site-packages/VERSION'
```

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library