### PR TITLE
chore: remove defer

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,6 +16,30 @@ from scenario import Container, Context, Model, Mount, Relation, State  # type: 
 from charm import NSSFOperatorCharm
 
 
+def get_tls_relation_with_certificates(certificate: str, csr: str):
+    """Returns a certificate Relation containing the given certificate and csr."""
+    tls_relation = Relation(
+        endpoint="certificates",
+        remote_app_name="tls-provider",
+        local_unit_data={
+            "certificate_signing_requests": json.dumps([{"certificate_signing_request": csr}])
+        },
+        remote_app_data={
+            "certificates": json.dumps(
+                [
+                    {
+                        "certificate": certificate,
+                        "certificate_signing_request": csr,
+                        "ca": "abc",
+                        "chain": ["abc", "def"],
+                    }
+                ]
+            )
+        },
+    )
+    return tls_relation
+
+
 class TestCharm(unittest.TestCase):
     def setUp(self):
         self.ctx = Context(NSSFOperatorCharm)
@@ -30,9 +54,7 @@ class TestCharm(unittest.TestCase):
             remote_app_name="tls-provider",
         )
 
-    def test_given_fiveg_nrf_relation_not_created_when_pebble_ready_then_status_is_blocked(
-        self,
-    ):
+    def test_given_fiveg_nrf_relation_not_created_when_pebble_ready_then_status_is_blocked(self):
         state_in = State(containers=[self.container], leader=True)
 
         state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
@@ -81,9 +103,8 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
-    @patch("charm.check_output")
     def test_given_nssf_charm_in_active_status_when_certificates_relation_breaks_then_status_is_blocked(  # noqa: E501
-        self, patch_check_output
+        self,
     ):
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
@@ -95,7 +116,6 @@ class TestCharm(unittest.TestCase):
             relations=[self.nrf_relation, self.tls_relation],
             unit_status=ActiveStatus(),
         )
-        patch_check_output.return_value = "1.1.1.1".encode()
 
         state_out = self.ctx.run(self.tls_relation.broken_event, state_in)
 
@@ -104,9 +124,25 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for certificates relation"),
         )
 
-    def test_given_nrf_data_not_available_when_pebble_ready_then_status_is_waiting(
+    def test_given_container_cannot_connect_when_certificates_relation_breaks_then_event_defer(  # noqa: E501
         self,
     ):
+        config_dir = tempfile.TemporaryDirectory()
+        container = self.container.replace(
+            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+            can_connect=False,
+        )
+        state_in = State(
+            leader=True,
+            containers=[container],
+            relations=[self.nrf_relation, self.tls_relation],
+        )
+
+        state_out = self.ctx.run(self.tls_relation.broken_event, state_in)
+
+        self.assertEqual(state_out.deferred[0].name, "certificates_relation_broken")
+
+    def test_given_nrf_data_not_available_when_pebble_ready_then_status_is_waiting(self):
         nrf_relation = Relation("fiveg_nrf")
         state_in = State(
             leader=True,
@@ -120,17 +156,17 @@ class TestCharm(unittest.TestCase):
             state_out.unit_status,
             WaitingStatus("Waiting for NRF data to be available"),
         )
-        self.assertEqual(
-            state_out.deferred[0].name,
-            "nssf_pebble_ready",
-        )
 
-    def test_given_relation_created_and_nrf_data_available_and_storage_not_attached_when_pebble_ready_then_status_is_waiting(  # noqa: E501
+    def test_given_relation_created_and_nrf_data_available_and_config_storage_not_attached_when_pebble_ready_then_status_is_waiting(  # noqa: E501
         self,
     ):
+        cert_dir = tempfile.TemporaryDirectory()
+        container = self.container.replace(
+            mounts={"cert_dir": Mount("/support/TLS", cert_dir.name)},
+        )
         state_in = State(
             leader=True,
-            containers=[self.container],
+            containers=[container],
             relations=[self.nrf_relation, self.tls_relation],
         )
 
@@ -140,19 +176,40 @@ class TestCharm(unittest.TestCase):
             state_out.unit_status,
             WaitingStatus("Waiting for storage to be attached"),
         )
-        self.assertEqual(
-            state_out.deferred[0].name,
-            "nssf_pebble_ready",
-        )
+        self.assertEqual(len(state_out.deferred), 0)
 
-    @patch("charm.check_output")
-    def test_given_relation_created_and_nrf_data_available_and_certificates_not_stored_when_pebble_ready_then_status_is_waiting(  # noqa: E501
+    def test_given_relations_created_and_nrf_data_available_and_certs_storage_not_attached_when_pebble_ready_then_status_is_waiting(  # noqa: E501
         self,
-        patch_check_output,
     ):
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
             mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+        )
+        state_in = State(
+            leader=True,
+            containers=[container],
+            relations=[self.nrf_relation, self.tls_relation],
+        )
+
+        state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
+
+        self.assertEqual(
+            state_out.unit_status,
+            WaitingStatus("Waiting for storage to be attached"),
+        )
+        self.assertEqual(len(state_out.deferred), 0)
+
+    @patch("charm.check_output")
+    def test_given_relations_created_and_nrf_data_available_and_certificates_not_stored_when_pebble_ready_then_status_is_waiting(  # noqa: E501
+        self, patch_check_output
+    ):
+        cert_dir = tempfile.TemporaryDirectory()
+        config_dir = tempfile.TemporaryDirectory()
+        container = self.container.replace(
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
         state_in = State(
             leader=True,
@@ -167,30 +224,34 @@ class TestCharm(unittest.TestCase):
             state_out.unit_status,
             WaitingStatus("Waiting for certificates to be stored"),
         )
-        self.assertEqual(
-            state_out.deferred[0].name,
-            "nssf_pebble_ready",
-        )
 
-    @patch("ops.model.Container.exists")
     @patch("charm.check_output")
     def test_given_relations_created_and_nrf_data_available_and_certificates_stored_when_pebble_ready_then_config_file_rendered_and_pushed(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_exists,
+        self, patch_check_output
     ):
+        csr = "whatever csr content"
+        certificate = "Whatever certificate content"
+        cert_dir = tempfile.TemporaryDirectory()
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
+
+        with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
+            nssf_csr_file.write(csr)
+
+        tls_relation = get_tls_relation_with_certificates(certificate, csr)
+
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation, self.tls_relation],
+            relations=[self.nrf_relation, tls_relation],
             model=Model(name="whatever"),
         )
         patch_check_output.return_value = b"1.1.1.1"
-        patch_exists.return_value = True
 
         self.ctx.run(container.pebble_ready_event, state_in)
 
@@ -202,30 +263,41 @@ class TestCharm(unittest.TestCase):
             expected_content = expected.read().strip()
             self.assertEqual(actual_content, expected_content)
 
-    @patch("ops.model.Container.exists")
     @patch("charm.check_output")
     def test_config_pushed_but_content_changed_when_pebble_ready_then_new_config_content_is_pushed(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_exists,
+        self, patch_check_output
     ):
+        cert_dir = tempfile.TemporaryDirectory()
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
+        certificate = "Whatever certificate content"
+        csr = "never gonna say goodbye"
+
+        with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
+            nssf_csr_file.write(csr)
+
+        tls_relation = get_tls_relation_with_certificates(certificate, csr)
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation, self.tls_relation],
+            relations=[self.nrf_relation, tls_relation],
             model=Model(name="whatever"),
         )
         patch_check_output.return_value = "1.1.1.1".encode()
-        patch_exists.return_value = True
+
         with open(Path(config_dir.name) / "nssfcfg.conf", "w") as existing_config:
             existing_config.write("never gonna give you up")
 
-        self.ctx.run(container.pebble_ready_event, state_in)
-
+        state_out = self.ctx.run(container.pebble_ready_event, state_in)
+        self.assertEqual(
+            state_out.unit_status,
+            ActiveStatus(),
+        )
         with (
             open(Path(config_dir.name) / "nssfcfg.conf") as actual,
             open(Path(__file__).parent / "expected_config" / "config.conf") as expected,
@@ -234,25 +306,30 @@ class TestCharm(unittest.TestCase):
             expected_content = expected.read().strip()
             self.assertEqual(actual_content, expected_content)
 
-    @patch("ops.model.Container.exists")
     @patch("charm.check_output")
-    def test_given_relation_available_and_config_pushed_when_pebble_ready_then_pebble_layer_is_added_correctly(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_exists,
+    def test_given_relations_available_and_config_pushed_when_pebble_ready_then_pebble_layer_is_added_correctly(  # noqa: E501
+        self, patch_check_output
     ):
+        cert_dir = tempfile.TemporaryDirectory()
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
+        csr = "never gonna say goodbye"
+        certificate = "Whatever certificate content"
+        tls_relation = get_tls_relation_with_certificates(certificate, csr)
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation, self.tls_relation],
+            relations=[self.nrf_relation, tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
-        patch_exists.return_value = True
 
+        with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
+            nssf_csr_file.write(csr)
         state_out = self.ctx.run(container.pebble_ready_event, state_in)
 
         expected_plan = {
@@ -276,40 +353,45 @@ class TestCharm(unittest.TestCase):
         updated_plan = state_out.containers[0].layers["nssf"]
         self.assertEqual(expected_plan, updated_plan)
 
-    @patch("ops.model.Container.exists")
     @patch("charm.check_output")
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_status_is_active(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_exists,
+        self, patch_check_output
     ):
+        cert_dir = tempfile.TemporaryDirectory()
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
+        csr = "never gonna say goodbye"
+        certificate = "Whatever certificate content"
+        tls_relation = get_tls_relation_with_certificates(certificate, csr)
+        with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
+            nssf_csr_file.write(csr)
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation, self.tls_relation],
+            relations=[self.nrf_relation, tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
-        patch_exists.return_value = True
 
         state_out = self.ctx.run(container.pebble_ready_event, state_in)
 
-        self.assertEqual(
-            state_out.unit_status,
-            ActiveStatus(),
-        )
+        self.assertEqual(state_out.unit_status, ActiveStatus())
 
     @patch("charm.check_output")
     def test_given_ip_not_available_when_pebble_ready_then_status_is_waiting(
-        self,
-        patch_check_output,
+        self, patch_check_output
     ):
         config_dir = tempfile.TemporaryDirectory()
+        cert_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
         state_in = State(
             leader=True,
@@ -325,26 +407,35 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for pod IP address to be available"),
         )
 
-    @patch("ops.model.Container.exists")
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_service_is_restarted(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_restart,
-        patch_exists,
+        self, patch_check_output, patch_restart
     ):
+
         config_dir = tempfile.TemporaryDirectory()
+        cert_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
+        csr = "never gonna say goodbye"
+        certificate = "Whatever certificate content"
+
+        tls_relation = get_tls_relation_with_certificates(certificate, csr)
+        with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
+            nssf_csr_file.write(csr)
+
+        with open(Path(cert_dir.name) / "nssf.pem", "w") as nssf_cert_file:
+            nssf_cert_file.write(certificate)
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation, self.tls_relation],
+            relations=[self.nrf_relation, tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
-        patch_exists.return_value = True
 
         self.ctx.run(container.pebble_ready_event, state_in)
 
@@ -353,9 +444,7 @@ class TestCharm(unittest.TestCase):
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
     def test_relations_available_and_config_pushed_and_pebble_layer_already_applied_when_pebble_ready_then_service_is_not_restarted(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_restart,
+        self, patch_check_output, patch_restart
     ):
         applied_plan = Layer(
             {
@@ -377,19 +466,31 @@ class TestCharm(unittest.TestCase):
                 }
             }
         )
+        cert_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
             mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
                 "config_dir": Mount(
                     "/free5gc/config/nssfcfg.conf",
                     Path(__file__).parent / "expected_config" / "config.conf",
-                )
+                ),
             },
             layers={"nssf": applied_plan},
         )
+        csr = "never gonna say goodbye"
+        certificate = "Whatever certificate content"
+
+        tls_relation = get_tls_relation_with_certificates(certificate, csr)
+        with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
+            nssf_csr_file.write(csr)
+
+        with open(Path(cert_dir.name) / "nssf.pem", "w") as nssf_cert_file:
+            nssf_cert_file.write(certificate)
+
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
 
@@ -397,16 +498,13 @@ class TestCharm(unittest.TestCase):
 
         patch_restart.assert_not_called()
 
-    @patch("ops.model.Container.exists")
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
     def test_config_pushed_but_content_changed_and_layer_already_applied_when_pebble_ready_then_nssf_service_is_restarted(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_restart,
-        patch_exists,
+        self, patch_check_output, patch_restart
     ):
         config_dir = tempfile.TemporaryDirectory()
+        cert_dir = tempfile.TemporaryDirectory()
         applied_plan = Layer(
             {
                 "services": {
@@ -427,26 +525,36 @@ class TestCharm(unittest.TestCase):
                 }
             }
         )
+        csr = "never gonna make you cry"
         container = self.container.replace(
-            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+            mounts={
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+            },
             layers={"nssf": applied_plan},
         )
+        with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
+            nssf_csr_file.write(csr)
+
+        certificate = "Whatever certificate content"
+
+        with open(Path(cert_dir.name) / "nssf.pem", "w") as nssf_cert_file:
+            nssf_cert_file.write(certificate)
+
+        tls_relation = get_tls_relation_with_certificates(certificate, csr)
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation, self.tls_relation],
+            relations=[self.nrf_relation, tls_relation],
             model=Model(name="whatever"),
         )
         patch_check_output.return_value = "1.1.1.1".encode()
-        patch_exists.return_value = True
 
         self.ctx.run(container.pebble_ready_event, state_in)
 
         patch_restart.assert_called_with("nssf")
 
-    def test_given_cannot_connect_to_container_when_nrf_available_then_status_is_waiting(
-        self,
-    ):
+    def test_given_cannot_connect_to_container_when_nrf_available_then_status_is_waiting(self):
         container = self.container.replace(can_connect=False)
         state_in = State(
             leader=True,
@@ -456,32 +564,48 @@ class TestCharm(unittest.TestCase):
 
         state_out = self.ctx.run(self.nrf_relation.changed_event, state_in)
 
-        self.assertEqual(
-            state_out.unit_status,
-            WaitingStatus("Waiting for container to start"),
-        )
-        self.assertEqual(
-            state_out.deferred[0].name,
-            "nrf_available",
-        )
+        self.assertEqual(state_out.unit_status, WaitingStatus("Waiting for container to start"))
 
-    @patch("charm.generate_private_key")
-    def test_given_can_connect_when_on_certificates_relation_created_then_private_key_is_generated(
-        self, patch_generate_private_key
+    def test_given_cannot_connect_to_container_when_certificates_relation_changed_then_status_is_waiting(  # noqa: E501
+        self,
     ):
-        cert_dir = tempfile.TemporaryDirectory()
-        container = self.container.replace(
-            mounts={"cert_dir": Mount("/support/TLS", cert_dir.name)},
-        )
-        private_key = b"private key content"
-        patch_generate_private_key.return_value = private_key
+        container = self.container.replace(can_connect=False)
         state_in = State(
             leader=True,
             containers=[container],
             relations=[self.nrf_relation, self.tls_relation],
         )
 
-        self.ctx.run(self.tls_relation.created_event, state_in)
+        state_out = self.ctx.run(self.tls_relation.joined_event, state_in)
+
+        self.assertEqual(state_out.unit_status, WaitingStatus("Waiting for container to start"))
+
+    @patch("charm.check_output")
+    @patch("charm.generate_private_key")
+    def test_given_can_connect_and_private_key_doesnt_exist_when_certificates_relation_joined_then_private_key_is_generated(  # noqa: E501
+        self, patch_generate_private_key, patch_check_output
+    ):
+        patch_check_output.return_value = "1.1.1.1".encode()
+        cert_dir = tempfile.TemporaryDirectory()
+        config_dir = tempfile.TemporaryDirectory()
+        container = self.container.replace(
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
+        )
+        private_key = b"private key content"
+        patch_generate_private_key.return_value = private_key
+        with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
+            nssf_csr_file.write("some csr")
+
+        state_in = State(
+            leader=True,
+            containers=[container],
+            relations=[self.nrf_relation, self.tls_relation],
+        )
+
+        self.ctx.run(self.tls_relation.joined_event, state_in)
 
         with open(Path(cert_dir.name) / "nssf.key") as nssf_key_file:
             actual_content = nssf_key_file.read()
@@ -511,13 +635,19 @@ class TestCharm(unittest.TestCase):
         "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
         new=Mock,
     )
+    @patch("charm.check_output")
     @patch("charm.generate_csr")
     def test_given_private_key_exists_when_on_certificates_relation_joined_then_csr_is_generated(
-        self, patch_generate_csr
+        self, patch_generate_csr, patch_check_output
     ):
+        patch_check_output.return_value = "1.1.1.1".encode()
         cert_dir = tempfile.TemporaryDirectory()
+        config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"cert_dir": Mount("/support/TLS", cert_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
         with open(Path(cert_dir.name) / "nssf.key", "w") as nssf_key_file:
             nssf_key_file.write("never gonna let you down")
@@ -538,15 +668,22 @@ class TestCharm(unittest.TestCase):
     @patch(
         "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
     )
+    @patch("charm.check_output")
     @patch("charm.generate_csr")
     def test_given_private_key_exists_and_certificate_not_yet_requested_when_on_certificates_relation_joined_then_cert_is_requested(  # noqa: E501
         self,
         patch_generate_csr,
+        patch_check_output,
         patch_request_certificate_creation,
     ):
+        patch_check_output.return_value = "1.1.1.1".encode()
         cert_dir = tempfile.TemporaryDirectory()
+        config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"cert_dir": Mount("/support/TLS", cert_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
         with open(Path(cert_dir.name) / "nssf.key", "w") as nssf_key_file:
             nssf_key_file.write("never gonna run around and desert you")
@@ -565,23 +702,26 @@ class TestCharm(unittest.TestCase):
     @patch(
         "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
     )
-    @patch("ops.model.Container.exists")
-    @patch("charm.generate_csr")
+    @patch("charm.check_output")
     def test_given_certificate_already_requested_when_on_certificates_relation_joined_then_cert_is_not_requested(  # noqa: E501
         self,
-        patch_generate_csr,
-        patch_exists,
+        patch_check_output,
         patch_request_certificate_creation,
     ):
+        patch_check_output.return_value = "1.1.1.1".encode()
         cert_dir = tempfile.TemporaryDirectory()
+        config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"cert_dir": Mount("/support/TLS", cert_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
-        with open(Path(cert_dir.name) / "ausf.key", "w") as ausf_key_file:
-            ausf_key_file.write("never gonna run around and desert you")
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
-        patch_exists.return_value = True
+        with open(Path(cert_dir.name) / "nssf.key", "w") as nssf_key_file:
+            nssf_key_file.write("never gonna run around and desert you")
+        with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
+            nssf_csr_file.write("whatever csr content")
+
         state_in = State(
             leader=True,
             containers=[container],
@@ -594,38 +734,23 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.check_output")
     def test_given_csr_matches_stored_one_when_certificate_available_then_certificate_is_pushed(
-        self,
-        patch_check_output,
+        self, patch_check_output
     ):
-        csr = "never gonna make you cry"
         cert_dir = tempfile.TemporaryDirectory()
+        config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"cert_dir": Mount("/support/TLS", cert_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
+
+        patch_check_output.return_value = b"1.2.3.4"
+        csr = "never gonna make you cry"
+        certificate = "Whatever certificate content"
+        tls_relation = get_tls_relation_with_certificates(certificate, csr)
         with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
             nssf_csr_file.write(csr)
-        patch_check_output.return_value = b"1.2.3.4"
-
-        certificate = "Whatever certificate content"
-        tls_relation = Relation(
-            endpoint="certificates",
-            remote_app_name="tls-provider",
-            local_unit_data={
-                "certificate_signing_requests": json.dumps([{"certificate_signing_request": csr}])
-            },
-            remote_app_data={
-                "certificates": json.dumps(
-                    [
-                        {
-                            "certificate": certificate,
-                            "certificate_signing_request": csr,
-                            "ca": "abc",
-                            "chain": ["abc", "def"],
-                        }
-                    ]
-                )
-            },
-        )
         state_in = State(
             leader=True,
             containers=[container],
@@ -638,47 +763,37 @@ class TestCharm(unittest.TestCase):
             actual_content = nssf_pem_file.read()
             self.assertEqual(actual_content, certificate)
 
-    def test_given_csr_doesnt_match_stored_one_when_certificate_available_then_certificate_is_not_pushed(  # noqa: E501
-        self,
+    @patch("charm.check_output")
+    def test_given_csr_doesnt_match_stored_one_when_certificate_available_then_status_is_waiting(  # noqa: E501
+        self, patch_check_output
     ):
+        patch_check_output.return_value = b"1.2.3.4"
         stored_csr = "never gonna say goodbye"
         cert_dir = tempfile.TemporaryDirectory()
+        config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
-            mounts={"cert_dir": Mount("/support/TLS", cert_dir.name)},
+            mounts={
+                "cert_dir": Mount("/support/TLS", cert_dir.name),
+                "config_dir": Mount("/free5gc/config", config_dir.name),
+            },
         )
         with open(Path(cert_dir.name) / "nssf.csr", "w") as nssf_csr_file:
             nssf_csr_file.write(stored_csr)
 
         relation_csr = "CSR in relation data (different from stored)"
         certificate = "Whatever certificate content"
-        tls_relation = Relation(
-            endpoint="certificates",
-            remote_app_name="tls-provider",
-            local_unit_data={
-                "certificate_signing_requests": json.dumps(
-                    [{"certificate_signing_request": relation_csr}]
-                )
-            },
-            remote_app_data={
-                "certificates": json.dumps(
-                    [
-                        {
-                            "certificate": certificate,
-                            "certificate_signing_request": relation_csr,
-                            "ca": "abc",
-                            "chain": ["abc", "def"],
-                        }
-                    ]
-                )
-            },
-        )
+        tls_relation = get_tls_relation_with_certificates(certificate, relation_csr)
         state_in = State(
             leader=True,
             containers=[container],
             relations=[self.nrf_relation, tls_relation],
         )
 
-        self.ctx.run(tls_relation.changed_event, state_in)
+        state_out = self.ctx.run(tls_relation.changed_event, state_in)
+        self.assertEqual(
+            state_out.unit_status,
+            WaitingStatus("Waiting for certificates to be stored"),
+        )
 
         with pytest.raises(FileNotFoundError):
             open(Path(cert_dir.name) / "nssf.pem")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,9 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-from charms.tls_certificates_interface.v3.tls_certificates import ProviderCertificate
+from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore[import]
+    ProviderCertificate,
+)
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer
 from scenario import Container, Context, Model, Mount, Relation, State  # type: ignore[import]
@@ -17,6 +19,7 @@ from scenario import Container, Context, Model, Mount, Relation, State  # type: 
 from charm import NSSFOperatorCharm
 
 CERTIFICATES_LIB_PATH = "charms.tls_certificates_interface.v3.tls_certificates"
+
 
 class TestCharm(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
# Description

Certificate relation joined and certificate available event are redirected to a centralized configure method.
Defers are removed from the centralized configure method.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library