### PR TITLE
chore: Centralize Status Management

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -71,7 +71,6 @@ class NSSFOperatorCharm(CharmBase):
         self.framework.observe(self.on.nssf_pebble_ready, self._configure_nssf)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_nssf)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_nssf)
-        self.framework.observe(self._nrf_requires.on.nrf_broken, self._configure_nssf)
         self.framework.observe(self.on.certificates_relation_joined, self._configure_nssf)
         self.framework.observe(
             self.on.certificates_relation_broken, self._on_certificates_relation_broken
@@ -144,7 +143,7 @@ class NSSFOperatorCharm(CharmBase):
 
         event.add_status(ActiveStatus())
 
-    def ready_to_configure(self) -> bool:
+    def _ready_to_configure(self) -> bool:
         """Returns whether the preconditions are met to proceed with the configuration.
 
         Returns:
@@ -201,7 +200,7 @@ class NSSFOperatorCharm(CharmBase):
         Args:
             event (EventBase): Juju event
         """
-        if not self.ready_to_configure():
+        if not self._ready_to_configure():
             logger.info("The preconditions for the configuration are not met yet.")
             return
 
@@ -236,11 +235,9 @@ class NSSFOperatorCharm(CharmBase):
         Returns:
             True if config update is required else False
         """
-        if not self._config_file_is_written() or not self._config_file_content_matches(
+        return not self._config_file_is_written() or not self._config_file_content_matches(
             content=content
-        ):
-            return True
-        return False
+        )
 
     def _config_file_is_written(self) -> bool:
         """Returns whether the config file was written to the workload container.

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,9 +18,16 @@ from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ign
     generate_private_key,
 )
 from jinja2 import Environment, FileSystemLoader
+from ops import (
+    ActiveStatus,
+    BlockedStatus,
+    CollectStatusEvent,
+    ModelError,
+    RelationBrokenEvent,
+    WaitingStatus,
+)
 from ops.charm import CharmBase, EventBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer, PathError
 
 logger = logging.getLogger(__name__)
@@ -45,13 +52,13 @@ class NSSFOperatorCharm(CharmBase):
 
     def __init__(self, *args) -> None:
         super().__init__(*args)
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         if not self.unit.is_leader():
             # NOTE: In cases where leader status is lost before the charm is
             # finished processing all teardown events, this prevents teardown
             # event code from running. Luckily, for this charm, none of the
-            # teardown code is necessary to preform if we're removing the
+            # teardown code is necessary to perform if we're removing the
             # charm.
-            self.unit.status = BlockedStatus("Scaling is not implemented for this charm")
             return
         self._container_name = self._service_name = "nssf"
         self._container = self.unit.get_container(self._container_name)
@@ -64,7 +71,7 @@ class NSSFOperatorCharm(CharmBase):
         self.framework.observe(self.on.nssf_pebble_ready, self._configure_nssf)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_nssf)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_nssf)
-        self.framework.observe(self._nrf_requires.on.nrf_broken, self._on_nrf_broken)
+        self.framework.observe(self._nrf_requires.on.nrf_broken, self._configure_nssf)
         self.framework.observe(self.on.certificates_relation_joined, self._configure_nssf)
         self.framework.observe(
             self.on.certificates_relation_broken, self._on_certificates_relation_broken
@@ -74,63 +81,220 @@ class NSSFOperatorCharm(CharmBase):
             self._certificates.on.certificate_expiring, self._on_certificate_expiring
         )
 
+    def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901
+        """Check the unit status and set to Unit when CollectStatusEvent is fired.
+
+        Args:
+            event: CollectStatusEvent
+        """
+        if not self.unit.is_leader():
+            # NOTE: In cases where leader status is lost before the charm is
+            # finished processing all teardown events, this prevents teardown
+            # event code from running. Luckily, for this charm, none of the
+            # teardown code is necessary to perform if we're removing the
+            # charm.
+            event.add_status(BlockedStatus("Scaling is not implemented for this charm"))
+            logger.info("Scaling is not implemented for this charm")
+            return
+
+        if not self._container.can_connect():
+            event.add_status(WaitingStatus("Waiting for container to start"))
+            logger.info("Waiting for container to start")
+            return
+
+        if invalid_configs := self._get_invalid_configs():
+            event.add_status(
+                BlockedStatus(f"The following configurations are not valid: {invalid_configs}")
+            )
+            logger.info("The following configurations are not valid: %s", invalid_configs)
+            return
+
+        for relation in ["fiveg_nrf", "certificates"]:
+            if not self.model.relations[relation]:
+                event.add_status(BlockedStatus(f"Waiting for {relation} relation"))
+                logger.info("Waiting for %s relation", relation)
+                return
+
+        if not self._nrf_data_is_available:
+            event.add_status(WaitingStatus("Waiting for NRF data to be available"))
+            logger.info("Waiting for NRF data to be available")
+            return
+
+        if not self._container.exists(path=CONFIG_DIR) or not self._container.exists(
+            path=CERTS_DIR_PATH
+        ):
+            event.add_status(WaitingStatus("Waiting for storage to be attached"))
+            logger.info("Waiting for storage to be attached")
+            return
+
+        if not _get_pod_ip():
+            event.add_status(WaitingStatus("Waiting for pod IP address to be available"))
+            logger.info("Waiting for pod IP address to be available")
+            return
+
+        if self._csr_is_stored() and not self._get_current_provider_certificate():
+            event.add_status(WaitingStatus("Waiting for certificates to be stored"))
+            logger.info("Waiting for certificates to be stored")
+            return
+
+        if not self._nssf_service_is_running():
+            event.add_status(WaitingStatus("Waiting for NSSF service to start"))
+            logger.info("Waiting for NSSF service to start")
+            return
+
+        event.add_status(ActiveStatus())
+
+    def ready_to_configure(self) -> bool:
+        """Returns whether the preconditions are met to proceed with the configuration.
+
+        Returns:
+            ready_to_configure: True if all conditions are met else False
+        """
+        if not self._container.can_connect():
+            return False
+
+        if self._get_invalid_configs():
+            return False
+
+        for relation in ["fiveg_nrf", "certificates"]:
+            if not self._relation_created(relation):
+                return False
+
+        if not self._nrf_data_is_available:
+            return False
+
+        if not self._storage_is_attached():
+            return False
+
+        if not _get_pod_ip():
+            return False
+
+        return True
+
+    def _storage_is_attached(self) -> bool:
+        """Returns whether storage is attached to the workload container.
+
+        Returns:
+            bool: Whether storage is attached.
+        """
+        return self._container.exists(path=CONFIG_DIR) and self._container.exists(
+            path=CERTS_DIR_PATH
+        )
+
+    def _nssf_service_is_running(self) -> bool:
+        """Check if the NSSF service is running.
+
+        Returns:
+            bool: Whether the NSSF service is running.
+        """
+        if not self._container.can_connect():
+            return False
+        try:
+            service = self._container.get_service(self._service_name)
+        except ModelError:
+            return False
+        return service.is_running()
+
     def _configure_nssf(self, event: EventBase) -> None:  # noqa: C901
         """Configure NSSF configuration file and pebble service.
 
         Args:
             event (EventBase): Juju event
         """
-        if not self._container.can_connect():
-            self.unit.status = WaitingStatus("Waiting for container to start")
-            return
-        if invalid_configs := self._get_invalid_configs():
-            self.unit.status = BlockedStatus(
-                f"The following configurations are not valid: {invalid_configs}"
-            )
-            return
-        for relation in ["fiveg_nrf", "certificates"]:
-            if not self._relation_created(relation):
-                self.unit.status = BlockedStatus(f"Waiting for {relation} relation")
-                return
-        if not self._nrf_data_is_available:
-            self.unit.status = WaitingStatus("Waiting for NRF data to be available")
-            return
-        if not self._container.exists(path=CONFIG_DIR) or not self._container.exists(
-            path=CERTS_DIR_PATH
-        ):
-            self.unit.status = WaitingStatus("Waiting for storage to be attached")
-            return
-        if not _get_pod_ip():
-            self.unit.status = WaitingStatus("Waiting for pod IP address to be available")
+        if not self.ready_to_configure():
+            logger.info("The preconditions for the configuration are not met yet.")
             return
 
         if not self._private_key_is_stored():
             self._generate_private_key()
+
         if not self._csr_is_stored():
             self._request_new_certificate()
 
         provider_certificate = self._get_current_provider_certificate()
         if not provider_certificate:
-            self.unit.status = WaitingStatus("Waiting for certificates to be stored")
             return
 
-        certificate_was_updated = self._update_certificate(
-            provider_certificate=provider_certificate
-        )
-        config_file_changed = self._apply_nssf_config()
-        should_restart = config_file_changed or certificate_was_updated
-        self._configure_nssf_service(force_restart=should_restart)
-        self.unit.status = ActiveStatus()
+        if certificate_update_required := self._is_certificate_update_required(
+            provider_certificate
+        ):
+            self._store_certificate(certificate=provider_certificate)
 
-    def _on_nrf_broken(self, event: EventBase) -> None:
-        """Event handler for NRF relation broken.
+        desired_config_file = self._generate_nssf_config_file()
+        if config_update_required := self._is_config_update_required(desired_config_file):
+            self._push_config_file(content=desired_config_file)
+
+        should_restart = config_update_required or certificate_update_required
+        self._configure_pebble(restart=should_restart)
+
+    def _is_config_update_required(self, content: str) -> bool:
+        """Decides whether config update is required by checking existence and config content.
 
         Args:
-            event (NRFBrokenEvent): Juju event
-        """
-        self.unit.status = BlockedStatus("Waiting for fiveg_nrf relation")
+            content (str): desired config file content
 
-    def _on_certificates_relation_broken(self, event: EventBase) -> None:
+        Returns:
+            True if config update is required else False
+        """
+        if not self._config_file_is_written() or not self._config_file_content_matches(
+            content=content
+        ):
+            return True
+        return False
+
+    def _config_file_is_written(self) -> bool:
+        """Returns whether the config file was written to the workload container.
+
+        Returns:
+            bool: Whether the config file was written.
+        """
+        return bool(self._container.exists(f"{CONFIG_DIR}/{CONFIG_FILE_NAME}"))
+
+    def _configure_pebble(self, restart: bool = False) -> None:
+        """Configure the Pebble layer.
+
+        Args:
+            restart (bool): Whether to restart the Pebble service. Defaults to False.
+        """
+        self._container.add_layer(self._container_name, self._pebble_layer, combine=True)
+        if restart:
+            self._container.restart(self._service_name)
+            logger.info("Restarted container %s", self._service_name)
+            return
+        self._container.replan()
+
+    def _is_certificate_update_required(self, provider_certificate) -> bool:
+        """Checks the provided certificate and existing certificate.
+
+        Returns True if update is required.
+
+        Args:
+            provider_certificate: str
+        Returns:
+            True if update is required else False
+        """
+        return self._get_existing_certificate() != provider_certificate
+
+    def _get_existing_certificate(self) -> str:
+        """Returns the existing certificate if present else empty string."""
+        return self._get_stored_certificate() if self._certificate_is_stored() else ""
+
+    def _generate_nssf_config_file(self) -> str:
+        """Handles creation of the NSSF config file based on a given template.
+
+        Returns:
+            content (str): desired config file content
+        """
+        return self._render_config_file(
+            sbi_port=SBI_PORT,
+            nrf_url=self._nrf_requires.nrf_url,
+            nssf_ip=_get_pod_ip(),  # type: ignore[arg-type]
+            sst=self._get_sst_config(),  # type: ignore[arg-type]
+            sd=self._get_sd_config(),  # type: ignore[arg-type]
+            scheme="https",
+        )
+
+    def _on_certificates_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Deletes TLS related artifacts and reconfigures workload."""
         if not self._container.can_connect():
             event.defer()
@@ -138,7 +302,6 @@ class NSSFOperatorCharm(CharmBase):
         self._delete_private_key()
         self._delete_csr()
         self._delete_certificate()
-        self.unit.status = BlockedStatus("Waiting for certificates relation")
 
     def _get_current_provider_certificate(self) -> str | None:
         """Compares the current certificate request to what is in the interface.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -115,6 +115,8 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect(container=self.container_name, val=True)
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for fiveg_nrf relation"),
@@ -126,6 +128,8 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect(container=self.container_name, val=True)
         self._create_nrf_relation()
         self.harness.container_pebble_ready(self.container_name)
+
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for certificates relation"),
@@ -154,6 +158,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(self.container_name)
 
         self.harness.remove_relation(nrf_relation_id)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for fiveg_nrf relation"),
@@ -186,8 +191,10 @@ class TestCharm(unittest.TestCase):
         cert_rel_id = self._create_certificates_relation()
 
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
         self.harness.remove_relation(cert_rel_id)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status, BlockedStatus("Waiting for certificates relation")
         )
@@ -219,6 +226,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.remove_relation(cert_rel_id)
         self.harness.set_can_connect(container=self.container_name, val=False)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status, WaitingStatus("Waiting for container to start")
         )
@@ -227,6 +235,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(relation_name=NRF_RELATION_NAME, remote_app="some_nrf_app")
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for NRF data to be available")
         )
@@ -257,6 +266,7 @@ class TestCharm(unittest.TestCase):
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
 
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status, WaitingStatus("Waiting for storage to be attached")
         )
@@ -286,6 +296,7 @@ class TestCharm(unittest.TestCase):
         (root / CONFIG_PATH).write_text("super different config file content")
 
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status, WaitingStatus("Waiting for storage to be attached")
         )
@@ -313,6 +324,7 @@ class TestCharm(unittest.TestCase):
         (root / CONFIG_PATH).write_text("super different config file content")
 
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status, WaitingStatus("Waiting for certificates to be stored")
         )
@@ -459,6 +471,7 @@ class TestCharm(unittest.TestCase):
         self._create_certificates_relation()
 
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
 
     @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
@@ -487,6 +500,7 @@ class TestCharm(unittest.TestCase):
         (root / CONFIG_PATH).write_text("super different config file content")
 
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status,
             WaitingStatus("Waiting for pod IP address to be available"),
@@ -519,6 +533,7 @@ class TestCharm(unittest.TestCase):
         self._create_certificates_relation()
 
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
         patch_restart.assert_called_with(self.container_name)
 
@@ -588,6 +603,7 @@ class TestCharm(unittest.TestCase):
         self._create_certificates_relation()
 
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus(""))
         patch_restart.assert_called_once_with(self.container_name)
 
@@ -601,6 +617,7 @@ class TestCharm(unittest.TestCase):
         patch_nrf_url.return_value = VALID_NRF_URL
         self._create_certificates_relation()
         self._create_nrf_relation()
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for container to start"),
@@ -615,6 +632,7 @@ class TestCharm(unittest.TestCase):
         self._create_nrf_relation()
         self._create_certificates_relation()
 
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for container to start"),
@@ -789,6 +807,7 @@ class TestCharm(unittest.TestCase):
         patch_get_assigned_certificates.return_value = [provider_certificate]
 
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for certificates to be stored"),


### PR DESCRIPTION
# Description

This PR uses new ops feature CollectStatus Event to manage status Charm. Event named collect_unit_status sets the status of charm automatically at the end of every hook.

Reference:

    - https://ops.readthedocs.io/en/latest/#ops.CollectStatusEvent
    - https://discourse.charmhub.io/t/how-to-set-a-charms-status/11771
   
This PR depends on unit test refactoring which is done by https://github.com/canonical/sdcore-nssf-k8s-operator/pull/85 and it must wait for it to be merged.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library