### PR TITLE
chore: Move to codespell and ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,24 +9,29 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
+[tool.ruff]
 line-length = 99
-target-version = ["py310"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"

--- a/src/charm.py
+++ b/src/charm.py
@@ -144,7 +144,7 @@ class NSSFOperatorCharm(CharmBase):
         event.add_status(ActiveStatus())
 
     def _ready_to_configure(self) -> bool:
-        """Returns whether the preconditions are met to proceed with the configuration.
+        """Return whether the preconditions are met to proceed with the configuration.
 
         Returns:
             ready_to_configure: True if all conditions are met else False
@@ -171,7 +171,7 @@ class NSSFOperatorCharm(CharmBase):
         return True
 
     def _storage_is_attached(self) -> bool:
-        """Returns whether storage is attached to the workload container.
+        """Return whether storage is attached to the workload container.
 
         Returns:
             bool: Whether storage is attached.
@@ -227,7 +227,7 @@ class NSSFOperatorCharm(CharmBase):
         self._configure_pebble(restart=should_restart)
 
     def _is_config_update_required(self, content: str) -> bool:
-        """Decides whether config update is required by checking existence and config content.
+        """Decide whether config update is required by checking existence and config content.
 
         Args:
             content (str): desired config file content
@@ -240,7 +240,7 @@ class NSSFOperatorCharm(CharmBase):
         )
 
     def _config_file_is_written(self) -> bool:
-        """Returns whether the config file was written to the workload container.
+        """Return whether the config file was written to the workload container.
 
         Returns:
             bool: Whether the config file was written.
@@ -261,7 +261,7 @@ class NSSFOperatorCharm(CharmBase):
         self._container.replan()
 
     def _is_certificate_update_required(self, provider_certificate) -> bool:
-        """Checks the provided certificate and existing certificate.
+        """Check the provided certificate and existing certificate.
 
         Returns True if update is required.
 
@@ -273,11 +273,11 @@ class NSSFOperatorCharm(CharmBase):
         return self._get_existing_certificate() != provider_certificate
 
     def _get_existing_certificate(self) -> str:
-        """Returns the existing certificate if present else empty string."""
+        """Return the existing certificate if present else empty string."""
         return self._get_stored_certificate() if self._certificate_is_stored() else ""
 
     def _generate_nssf_config_file(self) -> str:
-        """Handles creation of the NSSF config file based on a given template.
+        """Handle creation of the NSSF config file based on a given template.
 
         Returns:
             content (str): desired config file content
@@ -292,7 +292,7 @@ class NSSFOperatorCharm(CharmBase):
         )
 
     def _on_certificates_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Deletes TLS related artifacts and reconfigures workload."""
+        """Delete TLS related artifacts and reconfigures workload."""
         if not self._container.can_connect():
             event.defer()
             return
@@ -301,7 +301,7 @@ class NSSFOperatorCharm(CharmBase):
         self._delete_certificate()
 
     def _get_current_provider_certificate(self) -> str | None:
-        """Compares the current certificate request to what is in the interface.
+        """Compare the current certificate request to what is in the interface.
 
         Returns The current valid provider certificate if present
         """
@@ -312,7 +312,7 @@ class NSSFOperatorCharm(CharmBase):
         return None
 
     def _update_certificate(self, provider_certificate) -> bool:
-        """Compares the provided certificate to what is stored.
+        """Compare the provided certificate to what is stored.
 
         Returns True if the certificate was updated
         """
@@ -326,7 +326,7 @@ class NSSFOperatorCharm(CharmBase):
         return False
 
     def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
-        """Requests new certificate."""
+        """Request new certificate."""
         if not self._container.can_connect():
             event.defer()
             return
@@ -336,12 +336,12 @@ class NSSFOperatorCharm(CharmBase):
         self._request_new_certificate()
 
     def _generate_private_key(self) -> None:
-        """Generates and stores private key."""
+        """Generate and stores private key."""
         private_key = generate_private_key()
         self._store_private_key(private_key)
 
     def _request_new_certificate(self) -> None:
-        """Generates and stores CSR, and uses it to request a new certificate."""
+        """Generate and stores CSR, and uses it to request a new certificate."""
         private_key = self._get_stored_private_key()
         csr = generate_csr(
             private_key=private_key,
@@ -352,59 +352,59 @@ class NSSFOperatorCharm(CharmBase):
         self._certificates.request_certificate_creation(certificate_signing_request=csr)
 
     def _delete_private_key(self) -> None:
-        """Removes private key from workload."""
+        """Remove private key from workload."""
         if not self._private_key_is_stored():
             return
         self._container.remove_path(path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}")
         logger.info("Removed private key from workload")
 
     def _delete_csr(self) -> None:
-        """Deletes CSR from workload."""
+        """Delete CSR from workload."""
         if not self._csr_is_stored():
             return
         self._container.remove_path(path=f"{CERTS_DIR_PATH}/{CSR_NAME}")
         logger.info("Removed CSR from workload")
 
     def _delete_certificate(self) -> None:
-        """Deletes certificate from workload."""
+        """Delete certificate from workload."""
         if not self._certificate_is_stored():
             return
         self._container.remove_path(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}")
         logger.info("Removed certificate from workload")
 
     def _private_key_is_stored(self) -> bool:
-        """Returns whether private key is stored in workload."""
+        """Return whether private key is stored in workload."""
         return self._container.exists(path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}")
 
     def _csr_is_stored(self) -> bool:
-        """Returns whether CSR is stored in workload."""
+        """Return whether CSR is stored in workload."""
         return self._container.exists(path=f"{CERTS_DIR_PATH}/{CSR_NAME}")
 
     def _get_stored_certificate(self) -> str:
-        """Returns stored certificate."""
+        """Return stored certificate."""
         return str(self._container.pull(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}").read())
 
     def _get_stored_csr(self) -> str:
-        """Returns stored CSR."""
+        """Return stored CSR."""
         return str(self._container.pull(path=f"{CERTS_DIR_PATH}/{CSR_NAME}").read())
 
     def _get_stored_private_key(self) -> bytes:
-        """Returns stored private key."""
+        """Return stored private key."""
         return str(
             self._container.pull(path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}").read()
         ).encode()
 
     def _certificate_is_stored(self) -> bool:
-        """Returns whether certificate is stored in workload."""
+        """Return whether certificate is stored in workload."""
         return self._container.exists(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}")
 
     def _store_certificate(self, certificate: str) -> None:
-        """Stores certificate in workload."""
+        """Store certificate in workload."""
         self._container.push(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}", source=certificate)
         logger.info("Pushed certificate pushed to workload")
 
     def _store_private_key(self, private_key: bytes) -> None:
-        """Stores private key in workload."""
+        """Store private key in workload."""
         self._container.push(
             path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}",
             source=private_key.decode(),
@@ -412,12 +412,12 @@ class NSSFOperatorCharm(CharmBase):
         logger.info("Pushed private key to workload")
 
     def _store_csr(self, csr: bytes) -> None:
-        """Stores CSR in workload."""
+        """Store CSR in workload."""
         self._container.push(path=f"{CERTS_DIR_PATH}/{CSR_NAME}", source=csr.decode().strip())
         logger.info("Pushed CSR to workload")
 
     def _get_invalid_configs(self) -> list[str]:
-        """Returns list of invalid configurations.
+        """Return list of invalid configurations.
 
         Returns:
             list: List of strings matching config keys.
@@ -592,7 +592,7 @@ class NSSFOperatorCharm(CharmBase):
 
 
 def _get_pod_ip() -> Optional[str]:
-    """Returns the pod IP using juju client.
+    """Return the pod IP using juju client.
 
     Returns:
         str: The pod IP.

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,11 +1,7 @@
-black
+codespell
 coverage[toml]
-flake8-docstrings
-flake8-builtins
-isort
 mypy
-pep8-naming
-pyproject-flake8
 pytest
 pytest-operator
+ruff
 types-PyYAML

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,6 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-black==24.3.0
-    # via -r test-requirements.in
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -18,32 +16,25 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via black
+codespell==2.2.6
+    # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-flake8==7.0.0
-    # via
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.5.0
-    # via -r test-requirements.in
-flake8-docstrings==1.7.0
-    # via -r test-requirements.in
 google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
@@ -51,17 +42,19 @@ hvac==2.1.0
 idna==3.6
     # via requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.1
     # via ipdb
-isort==5.13.2
-    # via -r test-requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.4.0.0
     # via pytest-operator
 kubernetes==29.0.0
@@ -69,16 +62,15 @@ kubernetes==29.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
 mypy==1.9.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via
-    #   black
     #   mypy
     #   typing-inspect
 oauthlib==3.2.2
@@ -87,23 +79,19 @@ oauthlib==3.2.2
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   black
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
-pathspec==0.12.1
-    # via black
-pep8-naming==0.13.3
-    # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.2.0
-    # via black
 pluggy==1.4.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.3
@@ -119,14 +107,10 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.21
-    # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.2.0
-    # via flake8
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -136,14 +120,13 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==7.0.0
-    # via -r test-requirements.in
 pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -157,6 +140,7 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
@@ -170,6 +154,8 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.3.5
+    # via -r test-requirements.in
 six==1.16.0
     # via
     #   asttokens
@@ -177,8 +163,6 @@ six==1.16.0
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
 toposort==1.10
@@ -191,6 +175,7 @@ types-pyyaml==6.0.12.20240311
     # via -r test-requirements.in
 typing-extensions==4.10.0
     # via
+    #   -c requirements.txt
     #   mypy
     #   typing-inspect
 typing-inspect==0.9.0
@@ -202,6 +187,8 @@ urllib3==2.2.1
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,13 +5,12 @@ import unittest
 from unittest.mock import Mock, PropertyMock, patch
 
 import yaml
+from charm import CONFIG_FILE_NAME, NRF_RELATION_NAME, TLS_RELATION_NAME, NSSFOperatorCharm
 from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore[import]
     ProviderCertificate,
 )
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
-
-from charm import CONFIG_FILE_NAME, NRF_RELATION_NAME, TLS_RELATION_NAME, NSSFOperatorCharm
 
 POD_IP = b"1.1.1.1"
 PRIVATE_KEY = b"whatever key content"
@@ -60,7 +59,7 @@ class TestCharm(unittest.TestCase):
 
     @staticmethod
     def _get_metadata() -> dict:
-        """Reads `metadata.yaml` and returns it as a dictionary.
+        """Read `metadata.yaml` and returns it as a dictionary.
 
         Returns:
             dics: metadata.yaml as a dictionary.
@@ -71,7 +70,7 @@ class TestCharm(unittest.TestCase):
 
     @staticmethod
     def _read_file(path: str) -> str:
-        """Reads a file and returns as a string.
+        """Read a file and returns as a string.
 
         Args:
             path (str): path to the file.
@@ -84,7 +83,7 @@ class TestCharm(unittest.TestCase):
         return content
 
     def _create_nrf_relation(self) -> int:
-        """Creates NRF relation.
+        """Create NRF relation.
 
         Returns:
             int: relation id.
@@ -96,7 +95,7 @@ class TestCharm(unittest.TestCase):
         return relation_id
 
     def _create_certificates_relation(self) -> int:
-        """Creates certificates relation.
+        """Create certificates relation.
 
         Returns:
             int: relation id.

--- a/tox.ini
+++ b/tox.ini
@@ -28,15 +28,13 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
 
 [testenv:static]
 description = Run static analysis checks


### PR DESCRIPTION
# Description

Move to ruff and codespell for linting. `pyproject-flake8` is currently broken on Python 3.12, making development on Noble break.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library