### PR TITLE
chore: Use the rustup snap to install latest stable rust

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,8 +10,11 @@ bases:
 parts:
   charm:
     build-packages:
-      - cargo
       - libffi-dev
       - libssl-dev
       - pkg-config
-      - rustc
+    build-snaps:
+      - rustup
+    override-build: |
+      rustup default stable
+      craftctl default


### PR DESCRIPTION
# Description

This changes the way Rust and Cargo are installed for building the charm. Instead of using the deb packages available for the base, it uses the `rustup` snap to install the latest stable Rust and Cargo releases.

This will solve building issues for modules like pydantic that now depend on newer releases of Rust to build.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library