### PR TITLE
fix: Only replan if there are actual changes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -253,12 +253,17 @@ class NSSFOperatorCharm(CharmBase):
         Args:
             restart (bool): Whether to restart the Pebble service. Defaults to False.
         """
-        self._container.add_layer(self._container_name, self._pebble_layer, combine=True)
+        plan = self._container.get_plan()
+        if plan.services != self._pebble_layer.services:
+            self._container.add_layer(
+                self._container_name, self._pebble_layer, combine=True
+            )
+            self._container.replan()
+            logger.info("New layer added: %s", self._pebble_layer)
         if restart:
             self._container.restart(self._service_name)
             logger.info("Restarted container %s", self._service_name)
             return
-        self._container.replan()
 
     def _is_certificate_update_required(self, provider_certificate) -> bool:
         """Check the provided certificate and existing certificate.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -477,37 +477,6 @@ class TestCharm(unittest.TestCase):
     @patch("charm.check_output")
     @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("ops.model.Container.restart")
-    def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_is_not_ready_then_status_is_waiting_for_service(  # noqa: E501
-        self, _, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
-    ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = STORED_CERTIFICATE
-        provider_certificate.csr = STORED_CSR.decode()
-        patch_get_assigned_certificates.return_value = [provider_certificate]
-
-        root = self.harness.get_filesystem_root(self.container_name)
-        (root / CSR_PATH).write_text(STORED_CSR.decode())
-        (root / KEY_PATH).write_text(STORED_CERTIFICATE)
-        (root / CONFIG_PATH).write_text("super different config file content")
-
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
-
-        self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status, WaitingStatus("Waiting for NSSF service to start")
-        )
-
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_ip_not_available_when_pebble_ready_then_status_is_waiting(
         self, _, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
     ):


### PR DESCRIPTION
# Description

Rather than replanning with every status update, this change performs a comparison to ensure a replan is needed.

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- N/A Any dependent changes have been merged and published in downstream modules
- N/A I have bumped the version of the library