### PR TITLE
chore: use pytest for unit tests

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -194,11 +194,11 @@ class NSSFOperatorCharm(CharmBase):
             return False
         return service.is_running()
 
-    def _configure_nssf(self, event: EventBase) -> None:  # noqa: C901
+    def _configure_nssf(self, _: EventBase) -> None:  # noqa: C901
         """Configure NSSF configuration file and pebble service.
 
         Args:
-            event (EventBase): Juju event
+            _ (EventBase): Juju event
         """
         if not self._ready_to_configure():
             logger.info("The preconditions for the configuration are not met yet.")
@@ -455,8 +455,8 @@ class NSSFOperatorCharm(CharmBase):
             return True
         return False
 
+    @staticmethod
     def _render_config_file(
-        self,
         *,
         nssf_ip: str,
         sbi_port: int,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,9 +1,10 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
+from typing import Generator
 from unittest.mock import Mock, PropertyMock, patch
 
+import pytest
 import yaml
 from charm import CONFIG_FILE_NAME, NRF_RELATION_NAME, TLS_RELATION_NAME, NSSFOperatorCharm
 from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore[import]
@@ -12,6 +13,8 @@ from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ign
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
+CONTAINER_NAME = "nssf"
+NAMESPACE = "whatever"
 POD_IP = b"1.1.1.1"
 PRIVATE_KEY = b"whatever key content"
 VALID_NRF_URL = "http://nrf:8081"
@@ -27,7 +30,7 @@ STORED_CERTIFICATE = "whatever certificate content"
 STORED_CSR = b"whatever csr content"
 EXPECTED_PEBBLE_PLAN = {
     "services": {
-        "nssf": {
+        CONTAINER_NAME: {
             "startup": "enabled",
             "override": "replace",
             "command": "/bin/nssf --nssfcfg /free5gc/config/nssfcfg.conf",
@@ -45,17 +48,69 @@ EXPECTED_PEBBLE_PLAN = {
 }
 
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
-        self.maxDiff = None
-        self.namespace = "whatever"
-        self.metadata = self._get_metadata()
-        self.container_name = list(self.metadata["containers"].keys())[0]
+class TestCharm:
+    patcher_check_output = patch("charm.check_output")
+    patcher_nrf_url = patch(
+        "charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url",
+        new_callable=PropertyMock
+    )
+    patcher_generate_csr = patch("charm.generate_csr")
+    patcher_generate_private_key = patch("charm.generate_private_key")
+    patcher_get_assigned_certificates = patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates")  # noqa: E501
+    patcher_request_certificate_creation = patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation")  # noqa: E501
+    patcher_restart = patch("ops.model.Container.restart")
+
+    @pytest.fixture()
+    def setup(self):
+        self.mock_check_output = TestCharm.patcher_check_output.start()
+        self.mock_check_output.return_value = POD_IP
+        self.mock_nrf_url = TestCharm.patcher_nrf_url.start()
+        self.mock_nrf_url.return_value = VALID_NRF_URL
+        self.mock_generate_csr = TestCharm.patcher_generate_csr.start()
+        self.mock_generate_csr.return_value = STORED_CSR
+        self.mock_generate_private_key = TestCharm.patcher_generate_private_key.start()
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_get_assigned_certificates = TestCharm.patcher_get_assigned_certificates.start()
+        self.mock_request_certificate_creation = TestCharm.patcher_request_certificate_creation.start()  # noqa: E501
+        self.mock_restart = TestCharm.patcher_restart.start()
+
+    @staticmethod
+    def teardown() -> None:
+        patch.stopall()
+
+    @pytest.fixture(autouse=True)
+    def create_harness(self, setup, request):
         self.harness = testing.Harness(NSSFOperatorCharm)
-        self.harness.set_model_name(name=self.namespace)
-        self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_name(name=NAMESPACE)
         self.harness.set_leader(is_leader=True)
         self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.teardown)
+
+    @pytest.fixture()
+    def add_storage(self):
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+
+    @pytest.fixture()
+    def fiveg_nrf_relation_id(self) -> Generator[int, None, None]:
+        relation_id = self.harness.add_relation(
+            relation_name=NRF_RELATION_NAME,
+            remote_app="whatever-nrf",
+        )
+        self.harness.add_relation_unit(
+            relation_id=relation_id, remote_unit_name="whatever-nrf/0"
+        )
+        yield relation_id
+
+    @pytest.fixture()
+    def certificates_relation_id(self) -> Generator[int, None, None]:
+        relation_id = self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME,
+            remote_app="tls-certificates-operator",
+        )
+        yield relation_id
 
     @staticmethod
     def _get_metadata() -> dict:
@@ -82,761 +137,432 @@ class TestCharm(unittest.TestCase):
             content = f.read()
         return content
 
-    def _create_nrf_relation(self) -> int:
-        """Create NRF relation.
-
-        Returns:
-            int: relation id.
-        """
-        relation_id = self.harness.add_relation(
-            relation_name=NRF_RELATION_NAME, remote_app="nrf-operator"
-        )
-        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="nrf-operator/0")
-        return relation_id
-
-    def _create_certificates_relation(self) -> int:
-        """Create certificates relation.
-
-        Returns:
-            int: relation id.
-        """
-        relation_id = self.harness.add_relation(
-            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
-        )
-        self.harness.add_relation_unit(
-            relation_id=relation_id, remote_unit_name="tls-certificates-operator/0"
-        )
-        return relation_id
-
     def test_given_fiveg_nrf_relation_not_created_when_pebble_ready_then_status_is_blocked(
-        self,
+        self, certificates_relation_id
     ):
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        self._create_certificates_relation()
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
 
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg_nrf relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
 
     def test_given_certificates_relation_not_created_when_pebble_ready_then_status_is_blocked(
-        self,
+        self, fiveg_nrf_relation_id
     ):
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        self._create_nrf_relation()
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
 
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for certificates relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for certificates relation")
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_nssf_charm_in_active_status_when_nrf_relation_breaks_then_status_is_blocked(
-        self, _, patched_nrf_url, patch_check_output
+        self, add_storage, fiveg_nrf_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / CSR_PATH).write_text(STORED_CSR.decode())
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
         (root / CONFIG_PATH).write_text("super different config file content")
 
-        self._create_certificates_relation()
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
-        nrf_relation_id = self._create_nrf_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
 
-        self.harness.remove_relation(nrf_relation_id)
+        self.harness.remove_relation(fiveg_nrf_relation_id)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg_nrf relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_nssf_charm_in_active_status_when_certificates_relation_breaks_then_status_is_blocked(  # noqa: E501
-        self, _, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR.decode()
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / CSR_PATH).write_text(STORED_CSR.decode())
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
         (root / CONFIG_PATH).write_text("super different config file content")
 
-        self._create_nrf_relation()
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        cert_rel_id = self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
-        self.harness.remove_relation(cert_rel_id)
+        assert self.harness.charm.unit.status == ActiveStatus()
+        self.harness.remove_relation(certificates_relation_id)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status, BlockedStatus("Waiting for certificates relation")
-        )
+        assert self.harness.charm.unit.status == BlockedStatus("Waiting for certificates relation")
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_container_cannot_connect_when_certificates_relation_breaks_then_waiting_for_container_to_start(  # noqa: E501
-        self, _, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        root = self.harness.get_filesystem_root(self.container_name)
-        self._create_nrf_relation()
-        patch_check_output.return_value = POD_IP
-        patch_nrf_url.return_value = VALID_NRF_URL
-        cert_rel_id = self._create_certificates_relation()
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
 
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
         (root / CSR_PATH).write_text(STORED_CSR.decode())
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
         (root / CONFIG_PATH).write_text("super different config file content")
 
-        self.harness.remove_relation(cert_rel_id)
-        self.harness.set_can_connect(container=self.container_name, val=False)
+        self.harness.remove_relation(certificates_relation_id)
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=False)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status, WaitingStatus("Waiting for container to start")
-        )
+        assert self.harness.charm.unit.status == WaitingStatus("Waiting for container to start")
 
-    def test_given_nrf_data_not_available_when_pebble_ready_then_status_is_waiting(self):
-        self.harness.add_relation(relation_name=NRF_RELATION_NAME, remote_app="some_nrf_app")
-        self._create_certificates_relation()
-        self.harness.container_pebble_ready(self.container_name)
+    def test_given_nrf_data_not_available_when_pebble_ready_then_status_is_waiting(
+        self, fiveg_nrf_relation_id, certificates_relation_id
+    ):
+        self.mock_nrf_url.return_value = ""
+        self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for NRF data to be available")
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for NRF data to be available")  # noqa: E501
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_relation_created_and_nrf_data_available_and_config_storage_not_attached_when_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self, _, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, fiveg_nrf_relation_id, certificates_relation_id
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
 
-        self._create_nrf_relation()
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
         (root / CSR_PATH).write_text(STORED_CSR.decode())
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status, WaitingStatus("Waiting for storage to be attached")
-        )
+        assert self.harness.charm.unit.status == WaitingStatus("Waiting for storage to be attached")  # noqa: E501
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_relations_created_and_nrf_data_available_and_certs_storage_not_attached_when_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self, _, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, fiveg_nrf_relation_id, certificates_relation_id
     ):
         self.harness.add_storage(storage_name="config", attach=True)
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
 
-        self._create_nrf_relation()
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
         (root / CONFIG_PATH).write_text("super different config file content")
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status, WaitingStatus("Waiting for storage to be attached")
-        )
+        assert self.harness.charm.unit.status == WaitingStatus("Waiting for storage to be attached")  # noqa: E501
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_relations_created_and_nrf_data_available_and_certificates_not_stored_when_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self,
-        _,
-        patch_nrf_url,
-        patch_check_output,
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
 
-        root = self.harness.get_filesystem_root(self.container_name)
-
-        self._create_nrf_relation()
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
         (root / CONFIG_PATH).write_text("super different config file content")
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status, WaitingStatus("Waiting for certificates to be stored")
-        )
+        assert self.harness.charm.unit.status == WaitingStatus("Waiting for certificates to be stored")  # noqa: E501
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
-    @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_relations_created_and_nrf_data_available_and_certificates_stored_when_pebble_ready_then_config_file_rendered_and_pushed(  # noqa: E501
-        self,
-        patch_nrf_url,
-        patch_generate_private_key,
-        patch_check_output,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        patch_generate_private_key.return_value = PRIVATE_KEY
-        patch_generate_csr.return_value = STORED_CSR
+        self.mock_generate_csr.return_value = STORED_CSR
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR.decode()
-        patch_get_assigned_certificates.return_value = [
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
 
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
 
         with open(EXPECTED_CONFIG_FILE_PATH) as expected_config_file:
             expected_content = expected_config_file.read()
-        self.assertEqual((root / KEY_PATH).read_text(), PRIVATE_KEY.decode())
-        self.assertEqual((root / CERT_PATH).read_text(), STORED_CERTIFICATE)
-        self.assertEqual((root / CONFIG_PATH).read_text(), expected_content.strip())
+        assert (root / KEY_PATH).read_text() == PRIVATE_KEY.decode()
+        assert (root / CERT_PATH).read_text() == STORED_CERTIFICATE
+        assert (root / CONFIG_PATH).read_text() == expected_content.strip()
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
-    @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_config_pushed_but_content_changed_when_pebble_ready_then_new_config_content_is_pushed(  # noqa: E501
-        self,
-        patch_nrf_url,
-        patch_generate_private_key,
-        patch_check_output,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        patch_generate_private_key.return_value = PRIVATE_KEY
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_generate_csr.return_value = STORED_CSR
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.mock_generate_csr.return_value = STORED_CSR
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR.decode()
-        patch_get_assigned_certificates.return_value = [
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
         (root / CONFIG_PATH).write_text("Dummy content")
 
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_certificates_relation()
-        self._create_nrf_relation()
-
-        self.harness.container_pebble_ready("nssf")
+        self.harness.container_pebble_ready(CONTAINER_NAME)
 
         with open(EXPECTED_CONFIG_FILE_PATH) as expected_config_file:
             expected_content = expected_config_file.read()
-        self.assertEqual((root / KEY_PATH).read_text(), PRIVATE_KEY.decode())
-        self.assertEqual((root / CERT_PATH).read_text(), STORED_CERTIFICATE)
-        self.assertEqual((root / CONFIG_PATH).read_text(), expected_content.strip())
+        assert (root / KEY_PATH).read_text() == PRIVATE_KEY.decode()
+        assert (root / CERT_PATH).read_text() == STORED_CERTIFICATE
+        assert (root / CONFIG_PATH).read_text() == expected_content.strip()
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_relations_available_and_config_pushed_when_pebble_ready_then_pebble_layer_is_added_correctly(  # noqa: E501
-        self, _, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR.decode()
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / CSR_PATH).write_text(STORED_CSR.decode())
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
         (root / CONFIG_PATH).write_text("super different config file content")
 
-        self.harness.container_pebble_ready(self.container_name)
-        updated_plan = self.harness.get_container_pebble_plan(self.container_name).to_dict()
-        self.assertEqual(EXPECTED_PEBBLE_PLAN, updated_plan)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
+        updated_plan = self.harness.get_container_pebble_plan(CONTAINER_NAME).to_dict()
+        assert EXPECTED_PEBBLE_PLAN == updated_plan
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_status_is_active(  # noqa: E501
-        self, _, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR.decode()
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / CSR_PATH).write_text(STORED_CSR.decode())
         (root / KEY_PATH).write_text(STORED_CERTIFICATE)
         (root / CONFIG_PATH).write_text("super different config file content")
 
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+        assert self.harness.charm.unit.status == ActiveStatus()
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_ip_not_available_when_pebble_ready_then_status_is_waiting(
-        self, _, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        patch_check_output.return_value = "".encode()
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.mock_check_output.return_value = "".encode()
 
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / CSR_PATH).write_text(STORED_CSR.decode())
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
         (root / CONFIG_PATH).write_text("super different config file content")
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status,
-            WaitingStatus("Waiting for pod IP address to be available"),
-        )
+        assert self.harness.charm.unit.status == WaitingStatus("Waiting for pod IP address to be available")  # noqa: E501
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_service_is_restarted(  # noqa: E501
-        self, patch_restart, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR.decode()
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / CSR_PATH).write_text(STORED_CSR.decode())
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
         (root / CONFIG_PATH).write_text("super different config file content")
 
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
-        patch_restart.assert_called_with(self.container_name)
+        assert self.harness.model.unit.status == ActiveStatus()
+        self.mock_restart.assert_called_with(CONTAINER_NAME)
 
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
-    @patch("ops.model.Container.restart")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
     def test_relations_available_and_config_pushed_and_pebble_layer_already_applied_when_pebble_ready_then_service_is_not_restarted(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_get_assigned_certificates,
-        patch_nrf_url,
-        patch_restart,
-        patch_generate_private_key,
-        patch_generate_csr,
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        patch_generate_private_key.return_value = PRIVATE_KEY
-        patch_generate_csr.return_value = STORED_CSR
-
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
         (root / CONFIG_PATH).write_text(self._read_file(EXPECTED_CONFIG_FILE_PATH))
 
-        patch_nrf_url.return_value = VALID_NRF_URL
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
-        self.harness.container_pebble_ready(self.container_name)
-        patch_restart.assert_not_called()
+        self.harness.container_pebble_ready(CONTAINER_NAME)
+        self.mock_restart.assert_not_called()
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_config_pushed_but_content_changed_and_layer_already_applied_when_pebble_ready_then_nssf_service_is_restarted(  # noqa: E501
-        self, patch_restart, patch_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR.decode()
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / CSR_PATH).write_text(STORED_CSR.decode())
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
         (root / CONFIG_PATH).write_text(self._read_file(EXPECTED_CONFIG_FILE_PATH))
 
-        patch_check_output.return_value = b"1.2.3.4"
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.mock_check_output.return_value = b"1.2.3.4"
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus(""))
-        patch_restart.assert_called_once_with(self.container_name)
+        assert self.harness.model.unit.status == ActiveStatus("")
+        self.mock_restart.assert_called_once_with(CONTAINER_NAME)
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_cannot_connect_to_container_when_nrf_available_then_status_is_waiting(
-        self, patch_nrf_url
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        patch_nrf_url.return_value = VALID_NRF_URL
-        self._create_certificates_relation()
-        self._create_nrf_relation()
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for container to start"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for container to start")
 
     def test_given_cannot_connect_to_container_when_certificates_relation_changed_then_status_is_waiting(  # noqa: E501
-        self,
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        self._create_nrf_relation()
-        self._create_certificates_relation()
-
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for container to start"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for container to start")
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
-    @patch("charm.check_output")
     def test_given_can_connect_and_private_key_doesnt_exist_when_certificates_relation_joined_then_private_key_is_generated(  # noqa: E501
-        self, patch_check_output, patch_generate_private_key, patch_generate_csr, patched_nrf_url
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="config", attach=True)
-        self.harness.add_storage(storage_name="certs", attach=True)
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
 
-        patch_generate_private_key.return_value = PRIVATE_KEY
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_generate_csr.return_value = STORED_CSR
-        patched_nrf_url.return_value = VALID_NRF_URL
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.container_pebble_ready(CONTAINER_NAME)
 
-        self.harness.container_pebble_ready(self.container_name)
+        assert (root / KEY_PATH).read_text() == PRIVATE_KEY.decode()
 
-        self.assertEqual((root / KEY_PATH).read_text(), PRIVATE_KEY.decode())
-
-    def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_certificates_are_removed(  # noqa: E501
-        self,
-    ):
-        self.harness.set_can_connect(container=self.container_name, val=True)
+    def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_certificates_are_removed(self):  # noqa: E501
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
         self.harness.add_storage(storage_name="certs", attach=True)
 
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / KEY_PATH).write_text(PRIVATE_KEY.decode())
         (root / CSR_PATH).write_text(STORED_CSR.decode())
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
 
         self.harness.charm._on_certificates_relation_broken(event=Mock)
 
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / CERT_PATH).read_text()
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / KEY_PATH).read_text()
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / CSR_PATH).read_text()
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
     def test_given_private_key_exists_when_on_certificates_relation_joined_then_csr_is_generated(
-        self, patch_check_output, patch_generate_csr, patched_nrf_url
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        root = self.harness.get_filesystem_root(self.container_name)
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / KEY_PATH).write_text(PRIVATE_KEY.decode())
 
-        patch_generate_csr.return_value = STORED_CSR
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.container_pebble_ready(CONTAINER_NAME)
 
-        self.assertEqual((root / CSR_PATH).read_text(), STORED_CSR.decode())
+        assert (root / CSR_PATH).read_text() == STORED_CSR.decode()
 
-    @patch(
-        f"{CERTIFICATES_LIB}.request_certificate_creation",
-    )
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
     def test_given_private_key_exists_and_certificate_not_yet_requested_when_on_certificates_relation_joined_then_cert_is_requested(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_generate_csr,
-        patched_nrf_url,
-        patch_request_certificate_creation,
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / KEY_PATH).write_text(PRIVATE_KEY.decode())
 
-        patch_generate_csr.return_value = STORED_CSR
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
 
-        self._create_nrf_relation()
-        self._create_certificates_relation()
-
-        patch_request_certificate_creation.assert_called_with(
+        self.mock_request_certificate_creation.assert_called_with(
             certificate_signing_request=STORED_CSR
         )
 
-    @patch(f"{CERTIFICATES_LIB}.request_certificate_creation")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_certificate_already_requested_when_on_certificates_relation_joined_then_cert_is_not_requested(  # noqa: E501
-        self, patch_check_output, patched_nrf_url, patch_request_certificate_creation
+        self, add_storage, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / KEY_PATH).write_text(PRIVATE_KEY.decode())
         (root / CERT_PATH).write_text(STORED_CERTIFICATE)
 
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.mock_request_certificate_creation.assert_not_called()
 
-        patch_request_certificate_creation.assert_not_called()
-
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_csr_matches_stored_one_when_certificate_available_then_certificate_is_pushed(
-        self, patch_check_output, patched_nrf_url, patch_get_assigned_certificates
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / KEY_PATH).write_text(PRIVATE_KEY.decode())
         (root / CSR_PATH).write_text(STORED_CSR.decode())
 
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = STORED_CSR.decode()
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
 
-        self.assertEqual((root / CERT_PATH).read_text(), STORED_CERTIFICATE)
+        assert (root / CERT_PATH).read_text() == STORED_CERTIFICATE
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_csr_doesnt_match_stored_one_when_certificate_available_then_status_is_waiting(
-        self, patch_check_output, patched_nrf_url, patch_get_assigned_certificates
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / KEY_PATH).write_text(PRIVATE_KEY.decode())
         (root / CSR_PATH).write_text(STORED_CSR.decode())
 
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = "Relation CSR content (different from stored one)"
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for certificates to be stored"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for certificates to be stored")  # noqa: E501
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_csr_doesnt_match_stored_one_when_certificate_available_then_cert_is_not_pushed(
-        self, patch_check_output, patched_nrf_url, patch_get_assigned_certificates
+        self, add_storage, fiveg_nrf_relation_id, certificates_relation_id
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-
-        root = self.harness.get_filesystem_root(self.container_name)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / KEY_PATH).write_text(PRIVATE_KEY.decode())
         (root / CSR_PATH).write_text(STORED_CSR.decode())
 
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
-        self._create_nrf_relation()
-        self._create_certificates_relation()
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = STORED_CERTIFICATE
         provider_certificate.csr = "Relation CSR content (different from stored one)"
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_assigned_certificates.return_value = [provider_certificate]
 
-        self.harness.container_pebble_ready(self.container_name)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
 
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / CERT_PATH).read_text()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -393,8 +393,6 @@ class TestCharm:
         self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
 
         self.harness.container_pebble_ready(CONTAINER_NAME)
-        self.harness.evaluate_status()
-        assert self.harness.model.unit.status == ActiveStatus("")
         self.mock_restart.assert_called_once_with(CONTAINER_NAME)
 
     def test_given_cannot_connect_to_container_then_status_is_waiting(


### PR DESCRIPTION
# Description

This PR aims to remove `unittest` framework in favor of `pytest`, as described [here](https://juju.is/docs/sdk/write-a-unit-test-for-a-charm).
Main changes:
* Use fixtures to configure harness and patches
* Use fixtures to create `fiveg_nrf`, `certificates` relations
* Use fixture to add `certs` and `config` storage

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library