### PR TITLE
fix: Check Webui data availability in ready-to-configure method

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ juju integrate mongodb-k8s sdcore-nrf
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s sdcore-nssf-k8s
 juju integrate sdcore-nssf-k8s:certificates self-signed-certificates:certificates
-juju integrate sdcore-amf-k8s:sdcore_config sdcore-webui-k8s:sdcore-config
+juju integrate sdcore-nssf-k8s:sdcore_config sdcore-webui-k8s:sdcore-config
 ```
 
 ## Image

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ juju deploy self-signed-certificates
 juju integrate mongodb-k8s sdcore-nrf
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s sdcore-nssf-k8s
+juju integrate sdcore-nrf-k8s:sdcore_config sdcore-webui-k8s:sdcore-config
 juju integrate sdcore-nssf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nssf-k8s:sdcore_config sdcore-webui-k8s:sdcore-config
 ```

--- a/src/charm.py
+++ b/src/charm.py
@@ -132,7 +132,7 @@ class NSSFOperatorCharm(CharmBase):
             logger.info("Waiting for NRF data to be available")
             return
 
-        if not self._webui_requires.webui_url:
+        if not self._webui_data_is_available:
             event.add_status(WaitingStatus("Waiting for Webui data to be available"))
             logger.info("Waiting for Webui data to be available")
             return
@@ -179,6 +179,9 @@ class NSSFOperatorCharm(CharmBase):
         if not self._nrf_data_is_available:
             return False
 
+        if not self._webui_data_is_available:
+            return False
+
         if not self._storage_is_attached():
             return False
 
@@ -212,6 +215,10 @@ class NSSFOperatorCharm(CharmBase):
             if not self._relation_created(relation):
                 missing_relations.append(relation)
         return missing_relations
+
+    @property
+    def _webui_data_is_available(self) -> bool:
+        return bool(self._webui_requires.webui_url)
 
     def _nssf_service_is_running(self) -> bool:
         """Check if the NSSF service is running.

--- a/src/charm.py
+++ b/src/charm.py
@@ -92,6 +92,43 @@ class NSSFOperatorCharm(CharmBase):
         )
         self.framework.observe(self.on.sdcore_config_relation_joined, self._configure_nssf)
 
+    def _configure_nssf(self, _: EventBase) -> None:
+        """Handle Juju events.
+
+        This event handler is called for every event that affects the charm state
+        (ex. configuration files, relation data). This method performs a couple of checks
+        to make sure that the workload is ready to be started. Then, it configures the NSSF
+        workload and runs the Pebble services.
+
+        Args:
+            _ (EventBase): Juju event
+        """
+        if not self._ready_to_configure():
+            logger.info("The preconditions for the configuration are not met yet.")
+            return
+
+        if not self._private_key_is_stored():
+            self._generate_private_key()
+
+        if not self._csr_is_stored():
+            self._request_new_certificate()
+
+        provider_certificate = self._get_current_provider_certificate()
+        if not provider_certificate:
+            return
+
+        if certificate_update_required := self._is_certificate_update_required(
+            provider_certificate
+        ):
+            self._store_certificate(certificate=provider_certificate)
+
+        desired_config_file = self._generate_nssf_config_file()
+        if config_update_required := self._is_config_update_required(desired_config_file):
+            self._push_config_file(content=desired_config_file)
+
+        should_restart = config_update_required or certificate_update_required
+        self._configure_pebble(restart=should_restart)
+
     def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901
         """Check the unit status and set to Unit when CollectStatusEvent is fired.
 
@@ -233,38 +270,6 @@ class NSSFOperatorCharm(CharmBase):
         except ModelError:
             return False
         return service.is_running()
-
-    def _configure_nssf(self, _: EventBase) -> None:  # noqa: C901
-        """Configure NSSF configuration file and pebble service.
-
-        Args:
-            _ (EventBase): Juju event
-        """
-        if not self._ready_to_configure():
-            logger.info("The preconditions for the configuration are not met yet.")
-            return
-
-        if not self._private_key_is_stored():
-            self._generate_private_key()
-
-        if not self._csr_is_stored():
-            self._request_new_certificate()
-
-        provider_certificate = self._get_current_provider_certificate()
-        if not provider_certificate:
-            return
-
-        if certificate_update_required := self._is_certificate_update_required(
-            provider_certificate
-        ):
-            self._store_certificate(certificate=provider_certificate)
-
-        desired_config_file = self._generate_nssf_config_file()
-        if config_update_required := self._is_config_update_required(desired_config_file):
-            self._push_config_file(content=desired_config_file)
-
-        should_restart = config_update_required or certificate_update_required
-        self._configure_pebble(restart=should_restart)
 
     def _is_config_update_required(self, content: str) -> bool:
         """Decide whether config update is required by checking existence and config content.

--- a/src/charm.py
+++ b/src/charm.py
@@ -169,7 +169,7 @@ class NSSFOperatorCharm(CharmBase):
             logger.info("Waiting for NRF data to be available")
             return
 
-        if not self._webui_data_is_available:
+        if not self._webui_url_is_available:
             event.add_status(WaitingStatus("Waiting for Webui data to be available"))
             logger.info("Waiting for Webui data to be available")
             return
@@ -216,7 +216,7 @@ class NSSFOperatorCharm(CharmBase):
         if not self._nrf_data_is_available:
             return False
 
-        if not self._webui_data_is_available:
+        if not self._webui_url_is_available:
             return False
 
         if not self._storage_is_attached():
@@ -254,7 +254,7 @@ class NSSFOperatorCharm(CharmBase):
         return missing_relations
 
     @property
-    def _webui_data_is_available(self) -> bool:
+    def _webui_url_is_available(self) -> bool:
         return bool(self._webui_requires.webui_url)
 
     def _nssf_service_is_running(self) -> bool:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -26,7 +26,7 @@ TLS_PROVIDER_NAME = "self-signed-certificates"
 TLS_PROVIDER_CHANNEL = "latest/stable"
 GRAFANA_AGENT_APPLICATION_NAME = "grafana-agent-k8s"
 GRAFANA_AGENT_APPLICATION_CHANNEL = "latest/stable"
-WEBUI_CHARM_NAME = "sdcore-webui-k8s"
+WEBUI_APPLICATION_NAME = "sdcore-webui-k8s"
 WEBUI_CHARM_CHANNEL = "1.5/edge"
 TIMEOUT = 1000
 
@@ -53,8 +53,8 @@ async def _deploy_grafana_agent(ops_test: OpsTest):
 async def _deploy_webui(ops_test: OpsTest):
     assert ops_test.model
     await ops_test.model.deploy(
-        WEBUI_CHARM_NAME,
-        application_name=WEBUI_CHARM_NAME,
+        WEBUI_APPLICATION_NAME,
+        application_name=WEBUI_APPLICATION_NAME,
         channel=WEBUI_CHARM_CHANNEL,
     )
 
@@ -67,6 +67,7 @@ async def _deploy_sdcore_nrf_operator(ops_test: OpsTest):
         channel=NRF_APPLICATION_CHANNEL,
         trust=True,
     )
+
 
 
 async def _deploy_tls_provider(ops_test: OpsTest):
@@ -95,12 +96,15 @@ async def deploy(ops_test: OpsTest, request):
     await deploy_webui
     await ops_test.model.integrate(relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME)
     await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
-    await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=WEBUI_CHARM_NAME)
     await ops_test.model.integrate(
-        relation1=f"{WEBUI_CHARM_NAME}:common_database", relation2=f"{DB_APPLICATION_NAME}"
+        relation1=f"{WEBUI_APPLICATION_NAME}:common_database", relation2=f"{DB_APPLICATION_NAME}"
     )
     await ops_test.model.integrate(
-        relation1=f"{WEBUI_CHARM_NAME}:auth_database", relation2=f"{DB_APPLICATION_NAME}"
+        relation1=f"{WEBUI_APPLICATION_NAME}:auth_database", relation2=f"{DB_APPLICATION_NAME}"
+    )
+    await ops_test.model.integrate(
+        relation1=NRF_APPLICATION_NAME,
+        relation2=WEBUI_APPLICATION_NAME
     )
     resources = {
         "nssf-image": METADATA["resources"]["nssf-image"]["upstream-source"],
@@ -119,7 +123,7 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, deploy):
     await ops_test.model.integrate(relation1=APP_NAME, relation2=NRF_APPLICATION_NAME)
     await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_PROVIDER_NAME)
     await ops_test.model.integrate(
-        relation1=f"{APP_NAME}:sdcore_config", relation2=f"{WEBUI_CHARM_NAME}:sdcore-config"
+        relation1=f"{APP_NAME}:sdcore_config", relation2=f"{WEBUI_APPLICATION_NAME}:sdcore-config"
     )
     await ops_test.model.integrate(
         relation1=f"{APP_NAME}:logging", relation2=GRAFANA_AGENT_APPLICATION_NAME
@@ -141,15 +145,12 @@ async def test_remove_nrf_and_wait_for_blocked_status(ops_test: OpsTest, deploy)
 @pytest.mark.abort_on_fail
 async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, deploy):
     assert ops_test.model
-    await ops_test.model.deploy(
-        NRF_APPLICATION_NAME,
-        application_name=NRF_APPLICATION_NAME,
-        channel="edge",
-        trust=True,
-    )
-    await ops_test.model.integrate(relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME)
-    await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=WEBUI_CHARM_NAME)
+    await _deploy_sdcore_nrf_operator(ops_test)
+    await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=DB_APPLICATION_NAME)
     await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
+    await ops_test.model.integrate(
+        relation1=NRF_APPLICATION_NAME, relation2=WEBUI_APPLICATION_NAME
+    )
     await ops_test.model.integrate(relation1=APP_NAME, relation2=NRF_APPLICATION_NAME)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
 
@@ -164,12 +165,7 @@ async def test_remove_tls_and_wait_for_blocked_status(ops_test: OpsTest, deploy)
 @pytest.mark.abort_on_fail
 async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, deploy):
     assert ops_test.model
-    await ops_test.model.deploy(
-        TLS_PROVIDER_NAME,
-        application_name=TLS_PROVIDER_NAME,
-        channel="beta",
-        trust=True,
-    )
+    await _deploy_tls_provider(ops_test)
     await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_PROVIDER_NAME)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
 
@@ -177,7 +173,7 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, deploy)
 @pytest.mark.abort_on_fail
 async def test_remove_webui_and_wait_for_blocked_status(ops_test: OpsTest, deploy):
     assert ops_test.model
-    await ops_test.model.remove_application(WEBUI_CHARM_NAME, block_until_done=True)
+    await ops_test.model.remove_application(WEBUI_APPLICATION_NAME, block_until_done=True)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
 
 
@@ -186,13 +182,13 @@ async def test_restore_webui_and_wait_for_active_status(ops_test: OpsTest, deplo
     assert ops_test.model
     await _deploy_webui(ops_test)
     await ops_test.model.integrate(
-        relation1=f"{WEBUI_CHARM_NAME}:common_database", relation2=f"{DB_APPLICATION_NAME}"
+        relation1=f"{WEBUI_APPLICATION_NAME}:common_database", relation2=f"{DB_APPLICATION_NAME}"
     )
     await ops_test.model.integrate(
-        relation1=f"{WEBUI_CHARM_NAME}:auth_database", relation2=f"{DB_APPLICATION_NAME}"
+        relation1=f"{WEBUI_APPLICATION_NAME}:auth_database", relation2=f"{DB_APPLICATION_NAME}"
     )
     await ops_test.model.integrate(
-        relation1=f"{APP_NAME}:sdcore_config", relation2=f"{WEBUI_CHARM_NAME}:sdcore-config"
+        relation1=f"{APP_NAME}:sdcore_config", relation2=f"{WEBUI_APPLICATION_NAME}:sdcore-config"
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -95,6 +95,7 @@ async def deploy(ops_test: OpsTest, request):
     await deploy_webui
     await ops_test.model.integrate(relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME)
     await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
+    await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=WEBUI_CHARM_NAME)
     await ops_test.model.integrate(
         relation1=f"{WEBUI_CHARM_NAME}:common_database", relation2=f"{DB_APPLICATION_NAME}"
     )
@@ -147,6 +148,7 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, deploy)
         trust=True,
     )
     await ops_test.model.integrate(relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME)
+    await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=WEBUI_CHARM_NAME)
     await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
     await ops_test.model.integrate(relation1=APP_NAME, relation2=NRF_APPLICATION_NAME)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)


### PR DESCRIPTION
# Description

- Check Webui data availability before starting to configure NSSF.
- Fix application name in README.md
- Place _configure_nssf after constructor
- Change the docstring of _configure_nssf method
-  Separate the database deployment from NRF deployment in integration tests
- Use correct channels while deploying NRF and TLS charms in integration test
- Integrate NRF and Webui

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library