### PR TITLE
feat: adding workload version

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -53,6 +53,7 @@ LOGGING_RELATION_NAME = "logging"
 TLS_RELATION_NAME = "certificates"
 NRF_RELATION_NAME = "fiveg_nrf"
 SDCORE_CONFIG_RELATION_NAME = "sdcore_config"
+WORKLOAD_VERSION_FILE_NAME = "/etc/workload-version"
 
 
 class NSSFOperatorCharm(CharmBase):
@@ -98,10 +99,7 @@ class NSSFOperatorCharm(CharmBase):
         self.framework.observe(
             self._certificates.on.certificate_expiring, self._on_certificate_expiring
         )
-        self.framework.observe(
-            self._webui_requires.on.webui_url_available,
-            self._configure_nssf
-        )
+        self.framework.observe(self._webui_requires.on.webui_url_available, self._configure_nssf)
         self.framework.observe(self.on.sdcore_config_relation_joined, self._configure_nssf)
 
     def _configure_nssf(self, _: EventBase) -> None:
@@ -162,6 +160,8 @@ class NSSFOperatorCharm(CharmBase):
             logger.info("Waiting for container to start")
             return
 
+        self.unit.set_workload_version(self._get_workload_version())
+
         if invalid_configs := self._get_invalid_configs():
             event.add_status(
                 BlockedStatus(f"The following configurations are not valid: {invalid_configs}")
@@ -173,7 +173,7 @@ class NSSFOperatorCharm(CharmBase):
             event.add_status(
                 BlockedStatus(f"Waiting for {', '.join(missing_relations)} relation(s)")
             )
-            logger.info("Waiting for %s  relation(s)", ', '.join(missing_relations))
+            logger.info("Waiting for %s  relation(s)", ", ".join(missing_relations))
             return
 
         if not self._nrf_data_is_available:
@@ -258,9 +258,7 @@ class NSSFOperatorCharm(CharmBase):
             list: missing relation names.
         """
         missing_relations = []
-        for relation in [NRF_RELATION_NAME,
-                         TLS_RELATION_NAME,
-                         SDCORE_CONFIG_RELATION_NAME]:
+        for relation in [NRF_RELATION_NAME, TLS_RELATION_NAME, SDCORE_CONFIG_RELATION_NAME]:
             if not self._relation_created(relation):
                 missing_relations.append(relation)
         return missing_relations
@@ -312,9 +310,7 @@ class NSSFOperatorCharm(CharmBase):
         """
         plan = self._container.get_plan()
         if plan.services != self._pebble_layer.services:
-            self._container.add_layer(
-                self._container_name, self._pebble_layer, combine=True
-            )
+            self._container.add_layer(self._container_name, self._pebble_layer, combine=True)
             self._container.replan()
             logger.info("New layer added: %s", self._pebble_layer)
         if restart:
@@ -478,6 +474,24 @@ class NSSFOperatorCharm(CharmBase):
         """Store CSR in workload."""
         self._container.push(path=f"{CERTS_DIR_PATH}/{CSR_NAME}", source=csr.decode().strip())
         logger.info("Pushed CSR to workload")
+
+    def _get_workload_version(self) -> str:
+        """Return the workload version.
+
+        Checks for the presence of /etc/workload-version file
+        and if present, returns the contents of that file. If
+        the file is not present, an empty string is returned.
+
+        Returns:
+            string: A human readable string representing the
+            version of the workload
+        """
+        if self._container.exists(path=f"{WORKLOAD_VERSION_FILE_NAME}"):
+            version_file_content = self._container.pull(
+                path=f"{WORKLOAD_VERSION_FILE_NAME}"
+            ).read()
+            return version_file_content
+        return ""
 
     def _get_invalid_configs(self) -> list[str]:
         """Return list of invalid configurations.

--- a/src/charm.py
+++ b/src/charm.py
@@ -117,8 +117,6 @@ class NSSFOperatorCharm(CharmBase):
             logger.info("The preconditions for the configuration are not met yet.")
             return
 
-        self.unit.set_workload_version(self._get_workload_version())
-
         if not self._private_key_is_stored():
             self._generate_private_key()
 
@@ -144,6 +142,7 @@ class NSSFOperatorCharm(CharmBase):
     def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901
         """Check the unit status and set to Unit when CollectStatusEvent is fired.
 
+        Also sets the application unit workload version if present
         Args:
             event: CollectStatusEvent
         """
@@ -161,6 +160,8 @@ class NSSFOperatorCharm(CharmBase):
             event.add_status(WaitingStatus("Waiting for container to start"))
             logger.info("Waiting for container to start")
             return
+
+        self.unit.set_workload_version(self._get_workload_version())
 
         if invalid_configs := self._get_invalid_configs():
             event.add_status(

--- a/src/charm.py
+++ b/src/charm.py
@@ -117,6 +117,8 @@ class NSSFOperatorCharm(CharmBase):
             logger.info("The preconditions for the configuration are not met yet.")
             return
 
+        self.unit.set_workload_version(self._get_workload_version())
+
         if not self._private_key_is_stored():
             self._generate_private_key()
 
@@ -159,8 +161,6 @@ class NSSFOperatorCharm(CharmBase):
             event.add_status(WaitingStatus("Waiting for container to start"))
             logger.info("Waiting for container to start")
             return
-
-        self.unit.set_workload_version(self._get_workload_version())
 
         if invalid_configs := self._get_invalid_configs():
             event.add_status(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -712,6 +712,10 @@ class TestCharm:
 
     def test_given_no_workload_version_file_when_pebble_ready_then_workload_version_not_set(  # noqa: E501
         self,
+        add_storage,
+        fiveg_nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.container_pebble_ready(container_name=CONTAINER_NAME)
         self.harness.evaluate_status()
@@ -720,6 +724,10 @@ class TestCharm:
 
     def test_given_workload_version_file_when_pebble_ready_then_workload_version_set(
         self,
+        add_storage,
+        fiveg_nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         expected_version = "1.2.3"
         root = self.harness.get_filesystem_root(CONTAINER_NAME)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -713,9 +713,6 @@ class TestCharm:
     def test_given_no_workload_version_file_when_pebble_ready_then_workload_version_not_set(  # noqa: E501
         self,
         add_storage,
-        fiveg_nrf_relation_id,
-        certificates_relation_id,
-        sdcore_config_relation_id,
     ):
         self.harness.container_pebble_ready(container_name=CONTAINER_NAME)
         self.harness.evaluate_status()
@@ -724,10 +721,6 @@ class TestCharm:
 
     def test_given_workload_version_file_when_pebble_ready_then_workload_version_set(
         self,
-        add_storage,
-        fiveg_nrf_relation_id,
-        certificates_relation_id,
-        sdcore_config_relation_id,
     ):
         expected_version = "1.2.3"
         root = self.harness.get_filesystem_root(CONTAINER_NAME)


### PR DESCRIPTION
# Description

Checks the running container for a specific /etc/workload-version file. If it exists, the content of that file is reported in the app version field.

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library