### PR TITLE
fix: sdcore_config interface tests

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,3 +5,4 @@ pytest-interface-tester
 jsonschema
 cryptography
 cosl
+jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,8 @@ cryptography==43.0.0
     # via
     #   -r requirements.in
     #   paramiko
+exceptiongroup==1.2.2
+    # via pytest
 google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
@@ -40,6 +42,8 @@ idna==3.7
     # via requests
 iniconfig==2.0.0
     # via pytest
+jinja2==3.1.4
+    # via -r requirements.in
 jsonschema==4.23.0
     # via -r requirements.in
 jsonschema-specifications==2023.12.1
@@ -50,6 +54,8 @@ kubernetes==29.0.0
     # via juju
 macaroonbakery==1.3.4
     # via juju
+markupsafe==2.1.5
+    # via jinja2
 mypy-extensions==1.0.0
     # via typing-inspect
 oauthlib==3.2.2
@@ -141,6 +147,8 @@ six==1.16.0
     #   python-dateutil
 tenacity==9.0.0
     # via cosl
+tomli==2.0.1
+    # via pytest
 toposort==1.10
     # via juju
 typer==0.7.0

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -1,0 +1,40 @@
+import tempfile
+
+import pytest
+import scenario
+from charm import NSSFOperatorCharm
+from interface_tester import InterfaceTester
+from ops.pebble import Layer, ServiceStatus
+
+
+@pytest.fixture
+def interface_tester(interface_tester: InterfaceTester):
+    with tempfile.TemporaryDirectory() as tempdir:
+        config_mount = scenario.Mount(
+            location="/etc/nssf/",
+            src=tempdir,
+        )
+        certs_mount = scenario.Mount(
+            location="/support/TLS/",
+            src=tempdir,
+        )
+        container = scenario.Container(
+            name="nssf",
+            can_connect=True,
+            layers={"nrf": Layer({"services": {"nssf": {}}})},
+            service_status={
+                "nrf": ServiceStatus.ACTIVE,
+            },
+            mounts={
+                "config": config_mount,
+                "certs": certs_mount,
+            },
+        )
+        interface_tester.configure(
+            charm_type=NSSFOperatorCharm,
+            state_template=scenario.State(
+                leader=True,
+                containers=[container],
+            ),
+        )
+        yield interface_tester

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,10 @@ envlist = lint, static, unit
 
 [vars]
 src_path = {toxinidir}/src/
+interface_test_path = {toxinidir}/tests/interface/
 unit_test_path = {toxinidir}/tests/unit/
 integration_test_path = {toxinidir}/tests/integration/
-all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
+all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} {[vars]interface_test_path}
 
 [testenv]
 setenv =


### PR DESCRIPTION
# Description

`sdcore-config` interface tests in https://github.com/canonical/charm-relation-interfaces are failing.
This PR adds a fixture of the NSSF operator that will be used during `sdcore-config` provider tests
It also adds the `jinja2` dependency that was missing

https://github.com/canonical/charm-relation-interfaces/actions/runs/10444868384/job/28919962915
https://juju.is/docs/sdk/write-interface-tests

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library