### PR TITLE
chore: move to channel 6/stable in mongodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Charmed Operator for the Aether SD-Core Network Slice Selection Function (NSSF) 
 
 ## Usage
 ```bash
-juju deploy mongodb-k8s --trust --channel=6/beta
+juju deploy mongodb-k8s --trust --channel=6/stable
 juju deploy sdcore-nrf-k8s --channel=1.5/edge
 juju deploy sdcore-nssf-k8s --channel=1.5/edge
 juju deploy sdcore-nms-k8s --channel=1.5/edge

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,7 +17,7 @@ METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 DB_CHARM_NAME = "mongodb-k8s"
-DB_CHARM_CHANNEL = "6/beta"
+DB_CHARM_CHANNEL = "6/stable"
 NRF_CHARM_NAME = "sdcore-nrf-k8s"
 NRF_CHARM_CHANNEL = "1.5/edge"
 TLS_CHARM_NAME = "self-signed-certificates"


### PR DESCRIPTION
# Description

This PR sets the the `6/stable` channel for mongodb charm instead of `6/beta`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library