### PR TITLE
chore: Excludes pytest-asyncio from renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,5 +33,6 @@
       "groupName": "Terraform"
     },
   ],
+  // Bumping "pytest-asyncio" over 0.23 breaks the integration tests
   "ignoreDeps": ["pytest-asyncio"]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,4 +33,5 @@
       "groupName": "Terraform"
     },
   ],
+  "ignoreDeps": ["pytest-asyncio"]
 }


### PR DESCRIPTION
# Description

Excludes `pytest-asyncio` from renovate updates
With `pytest-asyncio > 0.23` our tests hang forever

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library