### PR TITLE
feat: add log-level configuration option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -75,3 +75,10 @@ parts:
       rustup default stable
       uv export --frozen --no-dev -o requirements.txt
       craftctl default
+
+config:
+  options:
+    log-level:
+      type: string
+      default: info
+      description: Log level for the NSSF. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.

--- a/src/templates/nssfcfg.conf.j2
+++ b/src/templates/nssfcfg.conf.j2
@@ -10,6 +10,9 @@ configuration:
   serviceNameList:
   - nnssf-nsselection
   - nnssf-nssaiavailability
+logger:
+  NSSF:
+    debugLevel: {{ log_level }}
 info:
   description: NSSF initial local configuration
   version: 1.0.0

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -10,6 +10,9 @@ configuration:
   serviceNameList:
   - nnssf-nsselection
   - nnssf-nssaiavailability
+logger:
+  NSSF:
+    debugLevel: info
 info:
   description: NSSF initial local configuration
   version: 1.0.0

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -35,6 +35,22 @@ class TestCharmCollectStatus(NSSFUnitTestFixtures):
 
         assert state_out.unit_status == WaitingStatus("Waiting for container to start")
 
+    def test_given_invalid_log_level_config_when_collect_unit_status_then_status_is_blocked(
+        self,
+    ):
+        container = testing.Container(name="nssf", can_connect=True)
+        state_in = testing.State(
+            leader=True,
+            config={"log-level": "invalid"},
+            containers={container},
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+            "The following configurations are not valid: ['log-level']"
+        )
+
     def test_given_relations_not_created_when_collect_unit_status_then_status_is_blocked(self):
         container = testing.Container(
             name="nssf",


### PR DESCRIPTION
# Description

Here we add a `log-level` configuration option with a reasonable default value (`info`). The allowed options are the same as in the workload: `debug`, `info`, `warn`, `error`, `fatal`, `panic`.

## Rationale

In most deployments, the log level should be set to `info` to ensure the log quantity is reasonable. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library