### PR TITLE
chore: bump nssf rock to v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ juju integrate sdcore-nssf-k8s:sdcore_config sdcore-nms-k8s:sdcore_config
 
 ## Image
 
-- **nssf**: `ghcr.io/canonical/sdcore-nssf:1.5.1`
+- **nssf**: `ghcr.io/canonical/sdcore-nssf:1.6.1`

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,9 +16,9 @@ containers:
     resource: nssf-image
     mounts:
       - storage: config
-        location: /free5gc/config/
+        location: /sdcore/config
       - storage: certs
-        location: /support/TLS
+        location: /sdcore/certs
 
 resources:
   nssf-image:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,7 +24,7 @@ resources:
   nssf-image:
     type: oci-image
     description: OCI image for 5G nssf
-    upstream-source: ghcr.io/canonical/sdcore-nssf:1.5.1
+    upstream-source: ghcr.io/canonical/sdcore-nssf:1.6.1
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -41,11 +41,11 @@ logger = logging.getLogger(__name__)
 
 PROMETHEUS_PORT = 8080
 SBI_PORT = 29531
-CONFIG_DIR = "/free5gc/config"
+CONFIG_DIR = "/sdcore/config"
 CONFIG_FILE_NAME = "nssfcfg.conf"
 CONFIG_TEMPLATE_DIR = "src/templates/"
 CONFIG_TEMPLATE_NAME = "nssfcfg.conf.j2"
-CERTS_DIR_PATH = "/support/TLS"  # Certificate paths are hardcoded in NSSF code
+CERTS_DIR_PATH = "/sdcore/certs"
 PRIVATE_KEY_NAME = "nssf.key"
 CERTIFICATE_NAME = "nssf.pem"
 CERTIFICATE_COMMON_NAME = "nssf.sdcore"
@@ -370,6 +370,8 @@ class NSSFOperatorCharm(CharmBase):
             nssf_ip=pod_ip,
             scheme="https",
             webui_uri=self._webui_requires.webui_url,
+            tls_pem=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}",
+            tls_key=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}",
             log_level=log_level,
         )
 
@@ -474,6 +476,8 @@ class NSSFOperatorCharm(CharmBase):
         nrf_url: str,
         scheme: str,
         webui_uri: str,
+        tls_pem: str,
+        tls_key: str,
         log_level: str,
     ):
         """Render the NSSF config file.
@@ -484,6 +488,8 @@ class NSSFOperatorCharm(CharmBase):
             nrf_url (str): URL of the NRF.
             scheme (str): SBI interface scheme ("http" or "https")
             webui_uri (str) : URL of the Webui
+            tls_pem (str): Path to the TLS certificate.
+            tls_key (str): Path to the TLS private key.
             log_level (str): Log level for the NSSF.
         """
         jinja2_environment = Environment(loader=FileSystemLoader(CONFIG_TEMPLATE_DIR))
@@ -494,6 +500,8 @@ class NSSFOperatorCharm(CharmBase):
             nssf_ip=nssf_ip,
             scheme=scheme,
             webui_uri=webui_uri,
+            tls_pem=tls_pem,
+            tls_key=tls_key,
             log_level=log_level,
         )
         return content

--- a/src/charm.py
+++ b/src/charm.py
@@ -550,7 +550,7 @@ class NSSFOperatorCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": f"/bin/nssf --nssfcfg {CONFIG_DIR}/{CONFIG_FILE_NAME}",  # noqa: E501
+                        "command": f"/bin/nssf --cfg {CONFIG_DIR}/{CONFIG_FILE_NAME}",  # noqa: E501
                         "environment": self._nssf_environment_variables,
                     },
                 },

--- a/src/templates/nssfcfg.conf.j2
+++ b/src/templates/nssfcfg.conf.j2
@@ -7,6 +7,9 @@ configuration:
     port: {{ sbi_port }}
     registerIPv4: {{ nssf_ip }}
     scheme: {{ scheme }}
+    tls:
+      pem: {{ tls_pem }}
+      key: {{ tls_key }}
   serviceNameList:
   - nnssf-nsselection
   - nnssf-nssaiavailability

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -7,6 +7,9 @@ configuration:
     port: 29531
     registerIPv4: 1.1.1.1
     scheme: https
+    tls:
+      pem: /sdcore/certs/nssf.pem
+      key: /sdcore/certs/nssf.key
   serviceNameList:
   - nnssf-nsselection
   - nnssf-nssaiavailability

--- a/tests/unit/test_charm_certificates_relation_broken.py
+++ b/tests/unit/test_charm_certificates_relation_broken.py
@@ -18,11 +18,11 @@ class TestCharmCertificatesRelationBroken(NSSFUnitTestFixtures):
                 endpoint="certificates", interface="tls-certificates"
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=tempdir,
             )
             config_mount = testing.Mount(
-                location="/free5gc/config",
+                location="/sdcore/config",
                 source=tempdir,
             )
             container = testing.Container(
@@ -30,8 +30,8 @@ class TestCharmCertificatesRelationBroken(NSSFUnitTestFixtures):
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            os.mkdir(f"{tempdir}/support")
-            os.mkdir(f"{tempdir}/support/TLS")
+            os.mkdir(f"{tempdir}/sdcore")
+            os.mkdir(f"{tempdir}/sdcore/certs")
             with open(f"{tempdir}/nssf.pem", "w") as f:
                 f.write("certificate")
 

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -200,11 +200,11 @@ class TestCharmCollectStatus(NSSFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/free5gc/config/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -244,11 +244,11 @@ class TestCharmCollectStatus(NSSFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/free5gc/config/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -289,11 +289,11 @@ class TestCharmCollectStatus(NSSFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/free5gc/config/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -335,11 +335,11 @@ class TestCharmCollectStatus(NSSFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/free5gc/config/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -30,11 +30,11 @@ class TestCharmConfigure(NSSFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/free5gc/config/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -82,11 +82,11 @@ class TestCharmConfigure(NSSFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/free5gc/config/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -140,11 +140,11 @@ class TestCharmConfigure(NSSFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/free5gc/config/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -175,7 +175,7 @@ class TestCharmConfigure(NSSFUnitTestFixtures):
                             "nssf": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/bin/nssf --cfg /free5gc/config/nssfcfg.conf",
+                                "command": "/bin/nssf --cfg /sdcore/config/nssfcfg.conf",
                                 "environment": {
                                     "POD_IP": "1.1.1.1",
                                     "MANAGED_BY_CONFIG_POD": "true",

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -175,7 +175,7 @@ class TestCharmConfigure(NSSFUnitTestFixtures):
                             "nssf": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/bin/nssf --nssfcfg /free5gc/config/nssfcfg.conf",
+                                "command": "/bin/nssf --cfg /free5gc/config/nssfcfg.conf",
                                 "environment": {
                                     "POD_IP": "1.1.1.1",
                                     "MANAGED_BY_CONFIG_POD": "true",


### PR DESCRIPTION
# Description

Bump the charm's rock/workload version to v1.6.1. We also make the necessary change for our charm to keep on working:
- We replace the existing nssfcfg startup CLI command with the new cfg
- We use the new parameters for providing the SBI interface's TLS certificate and key

## Reference
- https://github.com/omec-project/nssf/releases/tag/v1.6.1

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library