### PR TITLE
fix: use correct project name in tics workflow

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -9,6 +9,6 @@ jobs:
   tics-analysis:
     uses: canonical/sdcore-github-workflows/.github/workflows/tics-scan.yaml@v2.3.3
     with:
-      project: sdcore-amf-k8s-operator
+      project: sdcore-nssf-k8s-operator
     secrets:
       TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}


### PR DESCRIPTION
# Description

Use correct project name in tics workflow: replace `amf` with `nssf`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library