### PR TITLE
docs: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Aether SD-Core NSSF Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-nssf-k8s/badge.svg)](https://charmhub.io/sdcore-nssf-k8s)
 
+> **:warning: Deprecation Notice!**
+>
+> This project is deprecated and will not receive further updates. Please refer to the upstream [Aether](https://aetherproject.org/) project to continue using Aether.
+
 Charmed Operator for the Aether SD-Core Network Slice Selection Function (NSSF) for K8s.
 
 ## Usage


### PR DESCRIPTION
# Description

Add deprecation notice to let users know that we are deprecating Charmed Aether SD-Core.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library